### PR TITLE
feat: change the behavior of destroy warning

### DIFF
--- a/COMPARED_WITH_TFNOTIFY.md
+++ b/COMPARED_WITH_TFNOTIFY.md
@@ -10,6 +10,7 @@ tfcmt isn't compatible with tfnotify.
 * configuration file name is changed
 * command usage is changed
 * don't remove duplicated comments
+* change the behavior of deletion warning
 
 ### don't support platforms which we don't use
 
@@ -196,6 +197,35 @@ notifier:
   github:
     token: $GITHUB_TOKEN
 ```
+
+### change the behavior of deletion warning
+
+tfnotify posts a deletion warning comment as the other comment.
+tfcmt posts only one comment whose template is `when_destroy.template`.
+
+```yaml
+    when_destroy:
+      label: "destroy"
+      label_color: "d93f0b"  # red
+      template: |
+        {{ .Title }}
+
+        [CI link]( {{ .Link }} )
+
+        This plan contains **resource deletion**. Please check the plan result very carefully!
+
+        {{ .Message }}
+        {{if .Result}}
+        <pre><code>{{ .Result }}
+        </pre></code>
+        {{end}}
+        <details><summary>Details (Click me)</summary>
+
+        <pre><code>{{ .Body }}
+        </pre></code></details>
+```
+
+And the default title of destroy warning is changed to `## :warning: Resource Deletion will happen :warning:`.
 
 ## Others
 

--- a/terraform/template.go
+++ b/terraform/template.go
@@ -12,7 +12,7 @@ const (
 	// DefaultPlanTitle is a default title for terraform plan
 	DefaultPlanTitle = "## Plan result"
 	// DefaultDestroyWarningTitle is a default title of destroy warning
-	DefaultDestroyWarningTitle = "## WARNING: Resource Deletion will happen"
+	DefaultDestroyWarningTitle = "## :warning: Resource Deletion will happen :warning:"
 	// DefaultApplyTitle is a default title for terraform apply
 	DefaultApplyTitle = "## Apply result"
 

--- a/terraform/template_test.go
+++ b/terraform/template_test.go
@@ -188,7 +188,7 @@ func TestDestroyWarningTemplateExecute(t *testing.T) {
 			template: DefaultDestroyWarningTemplate,
 			value:    CommonTemplate{},
 			resp: `
-## WARNING: Resource Deletion will happen
+## :warning: Resource Deletion will happen :warning:
 
 This plan contains resource delete operation. Please check the plan result very carefully!
 


### PR DESCRIPTION
BREAKING CHANGE: change the behavior of destroy warning

---

## AS IS

tfcmt posts a deletion warning comment as the other comment.

## TO BE

tfcmt posts only one comment whose template is `when_destroy.template`.

```yaml
    when_destroy:
      label: "destroy"
      label_color: "d93f0b"  # red
      template: |
        {{ .Title }}
        [CI link]( {{ .Link }} )
        This plan contains **resource deletion**. Please check the plan result very carefully!
        {{ .Message }}
        {{if .Result}}
        <pre><code>{{ .Result }}
        </pre></code>
        {{end}}
        <details><summary>Details (Click me)</summary>
        <pre><code>{{ .Body }}
        </pre></code></details>
```

And the default title of destroy warning is changed to `## :warning: Resource Deletion will happen :warning:`.