### PR TITLE
docs: fix document

### DIFF
--- a/COMPARED_WITH_TFNOTIFY.md
+++ b/COMPARED_WITH_TFNOTIFY.md
@@ -10,7 +10,6 @@ tfcmt isn't compatible with tfnotify.
   * [Command usage is changed](#breaking-change-command-usage-is-changed)
   * [Don't remove duplicate comments](#breaking-change-dont-remove-duplicate-comments)
   * [Change the behavior of deletion warning](#breaking-change-change-the-behavior-of-deletion-warning)
-  * [Post a comment even if it failed to post a comment](#breaking-change-post-a-comment-even-if-it-failed-to-post-a-comment)
 * Features
   * [Post a comment when it failed to parse the result](#feature-post-a-comment-when-it-failed-to-parse-the-result)
   * [Find the configuration file recursively](#feature-find-the-configuration-file-recursively)
@@ -21,6 +20,8 @@ tfcmt isn't compatible with tfnotify.
   * [Add template variables](#feature-add-template-variables)
   * [Don't recreate labels](#feature-dont-recreate-labels)
   * [--version option and `version` command](#feature---version-option-and-version-command)
+* Fixes
+  * [Post a comment even if it failed to update labels](#fix-post-a-comment-even-if-it-failed-to-update-labels)
 * Others
   * refactoring
   * update urfave/cli to v2
@@ -127,17 +128,6 @@ tfcmt posts only one comment whose template is `when_destroy.template`.
 ```
 
 And the default title of destroy warning is changed to `## :warning: Resource Deletion will happen :warning:`.
-
-## Breaking Change: Post a comment even if it failed to post a comment
-
-[#35](https://github.com/suzuki-shunsuke/tfcmt/pull/35)
-
-tfnotify doesn't post a comment when it failed to update labels.
-For example, when the label length is too long, tfnotify failed to add the label and the comment isn't posted.
-tfnotify exits immediately and the exit code isn't non zero.
-
-On the other hand, tfcmt outputs the error log but the process continues even if it failed to update labels.
-And the exit code is same as the result of terraform command.
 
 ### Feature: Post a comment when it failed to parse the result
 
@@ -266,3 +256,12 @@ tfcmt version 0.1.0
 $ tfcmt version
 tfcmt version 0.1.0
 ```
+
+## Fix: Post a comment even if it failed to update labels
+
+[#35](https://github.com/suzuki-shunsuke/tfcmt/pull/35)
+
+tfnotify doesn't post a comment when it failed to update labels.
+For example, when the label length is too long, tfnotify failed to add the label and the comment isn't posted.
+
+On the other hand, tfcmt outputs the error log but the process continues even if it failed to update labels.

--- a/notifier/github/notify.go
+++ b/notifier/github/notify.go
@@ -61,7 +61,7 @@ func (g *NotifyService) Notify(ctx context.Context, param notifier.ParamExec) (i
 
 			currentLabelColor, err := g.removeResultLabels(ctx, labelToAdd)
 			if err != nil {
-				log.Printf("[ERROR][tfcmt] remove labelss: %v", err)
+				log.Printf("[ERROR][tfcmt] remove labels: %v", err)
 			}
 
 			if labelToAdd != "" {


### PR DESCRIPTION
* docs: fix a document. #35 has no breaking change
* fix: fix a typo