### PR TITLE
feat: add template variables CreatedResource, UpdatedResources, DeletedResources and ReplacedResources

### DIFF
--- a/COMPARED_WITH_TFNOTIFY.md
+++ b/COMPARED_WITH_TFNOTIFY.md
@@ -11,6 +11,7 @@ tfcmt isn't compatible with tfnotify.
   * [Don't remove duplicate comments](#breaking-change-dont-remove-duplicate-comments)
   * [Change the behavior of deletion warning](#breaking-change-change-the-behavior-of-deletion-warning)
 * Features
+  * [Add template variables of changed resource paths](#feature-add-template-variables-of-changed-resource-paths)
   * [Post a comment when it failed to parse the result](#feature-post-a-comment-when-it-failed-to-parse-the-result)
   * [Find the configuration file recursively](#feature-find-the-configuration-file-recursively)
   * [Complement CI and GitHub Repository owner and name from environment variables](#feature-complement-ci-and-github-repository-owner-and-name-from-environment-variables)
@@ -128,6 +129,51 @@ tfcmt posts only one comment whose template is `when_destroy.template`.
 ```
 
 And the default title of destroy warning is changed to `## :warning: Resource Deletion will happen :warning:`.
+
+### Feature: Add template variables of changed resource paths
+
+[#39](https://github.com/suzuki-shunsuke/tfcmt/pull/39)
+
+As a summary of the result of `terraform plan`, it is convenient to show a list of resource paths.
+So the following template variables are added.
+
+* `.CreatedResources`: a list of created resource paths ([]string)
+* `.UpdatedResources`: a list of updated resource paths ([]string)
+* `.DeletedResources`: a list of deleted resource paths ([]string)
+* `.ReplacedResources`: a list of replaced resource paths ([]string)
+
+For example,
+
+```
+{{if .CreatedResources}}
+* Create
+{{- range .CreatedResources}}
+  * {{.}}
+{{- end}}{{end}}{{if .UpdatedResources}}
+* Update
+{{- range .UpdatedResources}}
+  * {{.}}
+{{- end}}{{end}}{{if .DeletedResources}}
+* Delete
+{{- range .DeletedResources}}
+  * {{.}}
+{{- end}}{{end}}{{if .ReplacedResources}}
+* Replace
+{{- range .ReplacedResources}}
+  * {{.}}
+{{- end}}{{end}}
+```
+
+```
+* Create
+  * null_resource.foo
+* Update
+  * mysql_database.bar
+* Delete
+  * null_resource.bar
+* Replace
+  * mysql_database.foo
+```
 
 ### Feature: Post a comment when it failed to parse the result
 

--- a/README.md
+++ b/README.md
@@ -77,6 +77,10 @@ Placeholder | Usage
 `{{ .CombinedOutput }}` | The output of terraform command
 `{{ .ExitCode }}` | The exit code of terraform command
 `{{ .ErrorMessages }}` | a list of error messages which occur in tfcmt
+`{{ .CreatedResources }}` | a list of created resource paths. This variable can be used at only plan
+`{{ .UpdatedResources }}` | a list of updated resource paths. This variable can be used at only plan
+`{{ .DeletedResources }}` | a list of deleted resource paths. This variable can be used at only plan
+`{{ .ReplaecedResources }}` | a list of deleted resource paths. This variable can be used at only plan
 
 On GitHub, tfcmt can also put a warning message if the plan result contains resource deletion (optional).
 

--- a/notifier/github/notify.go
+++ b/notifier/github/notify.go
@@ -115,6 +115,8 @@ func (g *NotifyService) Notify(ctx context.Context, param notifier.ParamExec) (i
 		ExitCode:         param.ExitCode,
 		ErrorMessages:    errMsgs,
 		CreatedResources: result.CreatedResources,
+		UpdatedResources: result.UpdatedResources,
+		DeletedResources: result.DeletedResources,
 	})
 	body, err := template.Execute()
 	if err != nil {

--- a/notifier/github/notify.go
+++ b/notifier/github/notify.go
@@ -102,18 +102,19 @@ func (g *NotifyService) Notify(ctx context.Context, param notifier.ParamExec) (i
 	}
 
 	template.SetValue(terraform.CommonTemplate{
-		Title:          cfg.PR.Title,
-		Message:        cfg.PR.Message,
-		Result:         result.Result,
-		Body:           body,
-		Link:           cfg.CI,
-		UseRawOutput:   cfg.UseRawOutput,
-		Vars:           cfg.Vars,
-		Stdout:         param.Stdout,
-		Stderr:         param.Stderr,
-		CombinedOutput: param.CombinedOutput,
-		ExitCode:       param.ExitCode,
-		ErrorMessages:  errMsgs,
+		Title:            cfg.PR.Title,
+		Message:          cfg.PR.Message,
+		Result:           result.Result,
+		Body:             body,
+		Link:             cfg.CI,
+		UseRawOutput:     cfg.UseRawOutput,
+		Vars:             cfg.Vars,
+		Stdout:           param.Stdout,
+		Stderr:           param.Stderr,
+		CombinedOutput:   param.CombinedOutput,
+		ExitCode:         param.ExitCode,
+		ErrorMessages:    errMsgs,
+		CreatedResources: result.CreatedResources,
 	})
 	body, err := template.Execute()
 	if err != nil {

--- a/notifier/github/notify.go
+++ b/notifier/github/notify.go
@@ -102,21 +102,22 @@ func (g *NotifyService) Notify(ctx context.Context, param notifier.ParamExec) (i
 	}
 
 	template.SetValue(terraform.CommonTemplate{
-		Title:            cfg.PR.Title,
-		Message:          cfg.PR.Message,
-		Result:           result.Result,
-		Body:             body,
-		Link:             cfg.CI,
-		UseRawOutput:     cfg.UseRawOutput,
-		Vars:             cfg.Vars,
-		Stdout:           param.Stdout,
-		Stderr:           param.Stderr,
-		CombinedOutput:   param.CombinedOutput,
-		ExitCode:         param.ExitCode,
-		ErrorMessages:    errMsgs,
-		CreatedResources: result.CreatedResources,
-		UpdatedResources: result.UpdatedResources,
-		DeletedResources: result.DeletedResources,
+		Title:             cfg.PR.Title,
+		Message:           cfg.PR.Message,
+		Result:            result.Result,
+		Body:              body,
+		Link:              cfg.CI,
+		UseRawOutput:      cfg.UseRawOutput,
+		Vars:              cfg.Vars,
+		Stdout:            param.Stdout,
+		Stderr:            param.Stderr,
+		CombinedOutput:    param.CombinedOutput,
+		ExitCode:          param.ExitCode,
+		ErrorMessages:     errMsgs,
+		CreatedResources:  result.CreatedResources,
+		UpdatedResources:  result.UpdatedResources,
+		DeletedResources:  result.DeletedResources,
+		ReplacedResources: result.ReplacedResources,
 	})
 	body, err := template.Execute()
 	if err != nil {

--- a/terraform/template.go
+++ b/terraform/template.go
@@ -69,21 +69,22 @@ It failed to parse the result.
 
 // CommonTemplate represents template entities
 type CommonTemplate struct {
-	Title            string
-	Message          string
-	Result           string
-	Body             string
-	Link             string
-	UseRawOutput     bool
-	Vars             map[string]string
-	Stdout           string
-	Stderr           string
-	CombinedOutput   string
-	ExitCode         int
-	ErrorMessages    []string
-	CreatedResources []string
-	UpdatedResources []string
-	DeletedResources []string
+	Title             string
+	Message           string
+	Result            string
+	Body              string
+	Link              string
+	UseRawOutput      bool
+	Vars              map[string]string
+	Stdout            string
+	Stderr            string
+	CombinedOutput    string
+	ExitCode          int
+	ErrorMessages     []string
+	CreatedResources  []string
+	UpdatedResources  []string
+	DeletedResources  []string
+	ReplacedResources []string
 }
 
 // Template is a default template for terraform commands
@@ -174,20 +175,21 @@ func generateOutput(kind, template string, data map[string]interface{}, useRawOu
 // Execute binds the execution result of terraform command into template
 func (t *Template) Execute() (string, error) {
 	data := map[string]interface{}{
-		"Title":            t.Title,
-		"Message":          t.Message,
-		"Result":           t.Result,
-		"Body":             t.Body,
-		"Link":             t.Link,
-		"Vars":             t.Vars,
-		"Stdout":           t.Stdout,
-		"Stderr":           t.Stderr,
-		"CombinedOutput":   t.CombinedOutput,
-		"ExitCode":         t.ExitCode,
-		"ErrorMessages":    t.ErrorMessages,
-		"CreatedResources": t.CreatedResources,
-		"UpdatedResources": t.UpdatedResources,
-		"DeletedResources": t.DeletedResources,
+		"Title":             t.Title,
+		"Message":           t.Message,
+		"Result":            t.Result,
+		"Body":              t.Body,
+		"Link":              t.Link,
+		"Vars":              t.Vars,
+		"Stdout":            t.Stdout,
+		"Stderr":            t.Stderr,
+		"CombinedOutput":    t.CombinedOutput,
+		"ExitCode":          t.ExitCode,
+		"ErrorMessages":     t.ErrorMessages,
+		"CreatedResources":  t.CreatedResources,
+		"UpdatedResources":  t.UpdatedResources,
+		"DeletedResources":  t.DeletedResources,
+		"ReplacedResources": t.ReplacedResources,
 	}
 
 	resp, err := generateOutput("default", t.Template, data, t.UseRawOutput)

--- a/terraform/template.go
+++ b/terraform/template.go
@@ -82,6 +82,8 @@ type CommonTemplate struct {
 	ExitCode         int
 	ErrorMessages    []string
 	CreatedResources []string
+	UpdatedResources []string
+	DeletedResources []string
 }
 
 // Template is a default template for terraform commands
@@ -184,6 +186,8 @@ func (t *Template) Execute() (string, error) {
 		"ExitCode":         t.ExitCode,
 		"ErrorMessages":    t.ErrorMessages,
 		"CreatedResources": t.CreatedResources,
+		"UpdatedResources": t.UpdatedResources,
+		"DeletedResources": t.DeletedResources,
 	}
 
 	resp, err := generateOutput("default", t.Template, data, t.UseRawOutput)

--- a/terraform/template.go
+++ b/terraform/template.go
@@ -69,18 +69,19 @@ It failed to parse the result.
 
 // CommonTemplate represents template entities
 type CommonTemplate struct {
-	Title          string
-	Message        string
-	Result         string
-	Body           string
-	Link           string
-	UseRawOutput   bool
-	Vars           map[string]string
-	Stdout         string
-	Stderr         string
-	CombinedOutput string
-	ExitCode       int
-	ErrorMessages  []string
+	Title            string
+	Message          string
+	Result           string
+	Body             string
+	Link             string
+	UseRawOutput     bool
+	Vars             map[string]string
+	Stdout           string
+	Stderr           string
+	CombinedOutput   string
+	ExitCode         int
+	ErrorMessages    []string
+	CreatedResources []string
 }
 
 // Template is a default template for terraform commands
@@ -171,17 +172,18 @@ func generateOutput(kind, template string, data map[string]interface{}, useRawOu
 // Execute binds the execution result of terraform command into template
 func (t *Template) Execute() (string, error) {
 	data := map[string]interface{}{
-		"Title":          t.Title,
-		"Message":        t.Message,
-		"Result":         t.Result,
-		"Body":           t.Body,
-		"Link":           t.Link,
-		"Vars":           t.Vars,
-		"Stdout":         t.Stdout,
-		"Stderr":         t.Stderr,
-		"CombinedOutput": t.CombinedOutput,
-		"ExitCode":       t.ExitCode,
-		"ErrorMessages":  t.ErrorMessages,
+		"Title":            t.Title,
+		"Message":          t.Message,
+		"Result":           t.Result,
+		"Body":             t.Body,
+		"Link":             t.Link,
+		"Vars":             t.Vars,
+		"Stdout":           t.Stdout,
+		"Stderr":           t.Stderr,
+		"CombinedOutput":   t.CombinedOutput,
+		"ExitCode":         t.ExitCode,
+		"ErrorMessages":    t.ErrorMessages,
+		"CreatedResources": t.CreatedResources,
 	}
 
 	resp, err := generateOutput("default", t.Template, data, t.UseRawOutput)


### PR DESCRIPTION
As a summary of the result of `terraform plan`, it is convenient to show a list of resource paths.

* `.CreatedResources`: a list of created resource paths ([]string)
* `.UpdatedResources`: a list of updated resource paths ([]string)
* `.DeletedResources`: a list of deleted resource paths ([]string)
* `.ReplacedResources`: a list of replaced resource paths ([]string)

## Example

```yaml
        {{if .CreatedResources}}
        * Create
        {{- range .CreatedResources}}
          * {{.}}
        {{- end}}{{end}}{{if .UpdatedResources}}
        * Update
        {{- range .UpdatedResources}}
          * {{.}}
        {{- end}}{{end}}{{if .DeletedResources}}
        * Delete
        {{- range .DeletedResources}}
          * {{.}}
        {{- end}}{{end}}{{if .ReplacedResources}}
        * Replace
        {{- range .ReplacedResources}}
          * {{.}}
        {{- end}}{{end}}
```

```
* Create
  * null_resource.foo
* Update
  * mysql_database.bar
* Delete
  * null_resource.bar
* Replace
  * mysql_database.foo
```