### PR TITLE
remove `message` option and template variable `Message`

### DIFF
--- a/COMPARED_WITH_TFNOTIFY.md
+++ b/COMPARED_WITH_TFNOTIFY.md
@@ -8,6 +8,7 @@ tfcmt isn't compatible with tfnotify.
   * [Remove `fmt` command](#breaking-change-remove-fmt-command)
   * [Configuration file name is changed](#breaking-change-configuration-file-name-is-changed)
   * [Command usage is changed](#breaking-change-command-usage-is-changed)
+  * [Remove --message option and template variable .Message](#breaking-change-remove---message-option-and-template-variable-message)
   * [Don't remove duplicate comments](#breaking-change-dont-remove-duplicate-comments)
   * [Change the behavior of deletion warning](#breaking-change-change-the-behavior-of-deletion-warning)
 * Features
@@ -89,6 +90,11 @@ tfcmt apply -- terraform apply
 ```
 
 By this change, tfcmt can handle the standard error output and exit code of the terraform command.
+
+## Breaking Change: Remove --message option and template variable .Message
+
+We introduced more general option `-var` and template variable `.Vars`,
+so the `--message` option isn't needed.
 
 ## Breaking Change: Don't remove duplicate comments
 

--- a/COMPARED_WITH_TFNOTIFY.md
+++ b/COMPARED_WITH_TFNOTIFY.md
@@ -117,7 +117,6 @@ tfcmt posts only one comment whose template is `when_destroy.template`.
 
         This plan contains **resource deletion**. Please check the plan result very carefully!
 
-        {{ .Message }}
         {{if .Result}}
         <pre><code>{{ .Result }}
         </pre></code>
@@ -193,8 +192,6 @@ terraform:
 
         :warning: It failed to parse the result. :warning:
 
-        {{ .Message }}
-
         <details><summary>Details (Click me)</summary>
 
         <pre><code>{{ .CombinedOutput }}
@@ -205,8 +202,6 @@ terraform:
         {{ .Title }} <sup>[CI link]( {{ .Link }} )</sup>
 
         :warning: It failed to parse the result. :warning:
-
-        {{ .Message }}
 
         <details><summary>Details (Click me)</summary>
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,6 @@ The example settings of GitHub and GitHub Enterprise are as follows. Incidentall
 Placeholder | Usage
 ---|---
 `{{ .Title }}` | Like `## Plan result`
-`{{ .Message }}` | A string that can be set from CLI with `--message` option
 `{{ .Result }}` | Matched result by parsing like `Plan: 1 to add` or `No changes`
 `{{ .Body }}` | The entire of Terraform execution result
 `{{ .Link }}` | The link of the build page on CI
@@ -104,7 +103,6 @@ terraform:
   plan:
     template: |
       {{ .Title }} <sup>[CI link]( {{ .Link }} )</sup>
-      {{ .Message }}
       {{if .Result}}
       <pre><code>{{ .Result }}
       </pre></code>
@@ -116,7 +114,6 @@ terraform:
   apply:
     template: |
       {{ .Title }}
-      {{ .Message }}
       {{if .Result}}
       <pre><code>{{ .Result }}
       </pre></code>
@@ -137,7 +134,6 @@ terraform:
   plan:
     template: |
       {{ .Title }} <sup>[CI link]( {{ .Link }} )</sup>
-      {{ .Message }}
       {{if .Result}}
       <pre><code>{{ .Result }}
       </pre></code>
@@ -164,7 +160,6 @@ terraform:
   plan:
     template: |
       {{ .Title }} <sup>[CI link]( {{ .Link }} )</sup>
-      {{ .Message }}
       {{if .Result}}
       <pre><code>{{ .Result }}
       </pre></code>
@@ -202,7 +197,6 @@ terraform:
   plan:
     template: |
       {{ .Title }} <sup>[CI link]( {{ .Link }} )</sup>
-      {{ .Message }}
       {{if .Result}}
       ```
       {{ .Result }}
@@ -235,7 +229,6 @@ terraform:
   plan:
     template: |
       {{ .Title }} <sup>[CI link]( {{ .Link }} )</sup>
-      {{ .Message }}
       {{if .Result}}
       <pre><code>{{ .Result }}
       </pre></code>
@@ -247,7 +240,6 @@ terraform:
   apply:
     template: |
       {{ .Title }}
-      {{ .Message }}
       {{if .Result}}
       <pre><code>{{ .Result }}
       </pre></code>

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -40,7 +40,7 @@ func TestLoadFile(t *testing.T) {
 						Template: "",
 					},
 					Plan: Plan{
-						Template:    "{{ .Title }}\n{{ .Message }}\n{{if .Result}}\n<pre><code>{{ .Result }}\n</pre></code>\n{{end}}\n<details><summary>Details (Click me)</summary>\n\n<pre><code>{{ .Body }}\n</pre></code></details>\n",
+						Template:    "{{ .Title }}\n{{if .Result}}\n<pre><code>{{ .Result }}\n</pre></code>\n{{end}}\n<details><summary>Details (Click me)</summary>\n\n<pre><code>{{ .Body }}\n</pre></code></details>\n",
 						WhenDestroy: WhenDestroy{},
 					},
 					Apply: Apply{
@@ -70,7 +70,7 @@ func TestLoadFile(t *testing.T) {
 						Template: "",
 					},
 					Plan: Plan{
-						Template: "{{ .Title }}\n{{ .Message }}\n{{if .Result}}\n<pre><code>{{ .Result }}\n</pre></code>\n{{end}}\n<details><summary>Details (Click me)</summary>\n\n<pre><code>{{ .Body }}\n</pre></code></details>\n",
+						Template: "{{ .Title }}\n{{if .Result}}\n<pre><code>{{ .Result }}\n</pre></code>\n{{end}}\n<details><summary>Details (Click me)</summary>\n\n<pre><code>{{ .Body }}\n</pre></code></details>\n",
 						WhenAddOrUpdateOnly: WhenAddOrUpdateOnly{
 							Label: "add-or-update",
 						},
@@ -112,7 +112,7 @@ func TestLoadFile(t *testing.T) {
 						Template: "",
 					},
 					Plan: Plan{
-						Template:    "{{ .Title }}\n{{ .Message }}\n{{if .Result}}\n<pre><code>{{ .Result }}\n</pre></code>\n{{end}}\n<details><summary>Details (Click me)</summary>\n\n<pre><code>{{ .Body }}\n</pre></code></details>\n",
+						Template:    "{{ .Title }}\n{{if .Result}}\n<pre><code>{{ .Result }}\n</pre></code>\n{{end}}\n<details><summary>Details (Click me)</summary>\n\n<pre><code>{{ .Body }}\n</pre></code></details>\n",
 						WhenDestroy: WhenDestroy{},
 					},
 					Apply: Apply{

--- a/example-use-raw-output.tfcmt.yaml
+++ b/example-use-raw-output.tfcmt.yaml
@@ -10,7 +10,6 @@ terraform:
   plan:
     template: |
       {{ .Title }}
-      {{ .Message }}
       {{if .Result}}
       <pre><code>{{ .Result }}
       </pre></code>

--- a/example-with-destroy-and-result-labels.tfcmt.yaml
+++ b/example-with-destroy-and-result-labels.tfcmt.yaml
@@ -9,7 +9,6 @@ terraform:
   plan:
     template: |
       {{ .Title }}
-      {{ .Message }}
       {{if .Result}}
       <pre><code>{{ .Result }}
       </pre></code>

--- a/example.tfcmt.yaml
+++ b/example.tfcmt.yaml
@@ -9,7 +9,6 @@ terraform:
   plan:
     template: |
       {{ .Title }}
-      {{ .Message }}
       {{if .Result}}
       <pre><code>{{ .Result }}
       </pre></code>

--- a/main.go
+++ b/main.go
@@ -112,7 +112,6 @@ func (t *tfcmt) getNotifier(ctx context.Context, ci CI) (notifier.Notifier, erro
 			Revision:              ci.PR.Revision,
 			Number:                ci.PR.Number,
 			Title:                 t.context.String("title"),
-			Message:               t.context.String("message"),
 			DestroyWarningTitle:   t.context.String("destroy-warning-title"),
 			DestroyWarningMessage: t.context.String("destroy-warning-message"),
 		},
@@ -196,10 +195,6 @@ func main() {
 					Usage: "Specify the title to use for notification",
 				},
 				&cli.StringFlag{
-					Name:  "message, m",
-					Usage: "Specify the message to use for notification",
-				},
-				&cli.StringFlag{
 					Name:  "destroy-warning-title",
 					Usage: "Specify the title to use for destroy warning notification",
 				},
@@ -217,10 +212,6 @@ func main() {
 				&cli.StringFlag{
 					Name:  "title, t",
 					Usage: "Specify the title to use for notification",
-				},
-				&cli.StringFlag{
-					Name:  "message, m",
-					Usage: "Specify the message to use for notification",
 				},
 			},
 		},

--- a/notifier/github/notify.go
+++ b/notifier/github/notify.go
@@ -103,7 +103,6 @@ func (g *NotifyService) Notify(ctx context.Context, param notifier.ParamExec) (i
 
 	template.SetValue(terraform.CommonTemplate{
 		Title:             cfg.PR.Title,
-		Message:           cfg.PR.Message,
 		Result:            result.Result,
 		Body:              body,
 		Link:              cfg.CI,

--- a/terraform/template.go
+++ b/terraform/template.go
@@ -19,8 +19,6 @@ const (
 	defaultTemplate = `
 {{ .Title }}
 
-{{ .Message }}
-
 {{if .Result}}
 <pre><code>{{ .Result }}
 </code></pre>
@@ -58,8 +56,6 @@ This plan contains resource delete operation. Please check the plan result very 
 
 It failed to parse the result.
 
-{{ .Message }}
-
 <details><summary>Details (Click me)</summary>
 
 <pre><code>{{ .CombinedOutput }}
@@ -70,7 +66,6 @@ It failed to parse the result.
 // CommonTemplate represents template entities
 type CommonTemplate struct {
 	Title             string
-	Message           string
 	Result            string
 	Body              string
 	Link              string
@@ -176,7 +171,6 @@ func generateOutput(kind, template string, data map[string]interface{}, useRawOu
 func (t *Template) Execute() (string, error) {
 	data := map[string]interface{}{
 		"Title":             t.Title,
-		"Message":           t.Message,
 		"Result":            t.Result,
 		"Body":              t.Body,
 		"Link":              t.Link,

--- a/terraform/template_test.go
+++ b/terraform/template_test.go
@@ -21,8 +21,6 @@ func TestPlanTemplateExecute(t *testing.T) {
 
 
 
-
-
 <details><summary>Details (Click me)</summary>
 
 <pre><code>
@@ -33,15 +31,12 @@ func TestPlanTemplateExecute(t *testing.T) {
 			name:     "case 1",
 			template: DefaultPlanTemplate,
 			value: CommonTemplate{
-				Title:   "title",
-				Message: "message",
-				Result:  "result",
-				Body:    "body",
+				Title:  "title",
+				Result: "result",
+				Body:   "body",
 			},
 			resp: `
 title
-
-message
 
 
 <pre><code>result
@@ -58,15 +53,12 @@ message
 			name:     "case 2",
 			template: DefaultPlanTemplate,
 			value: CommonTemplate{
-				Title:   "title",
-				Message: "message",
-				Result:  "",
-				Body:    "body",
+				Title:  "title",
+				Result: "",
+				Body:   "body",
 			},
 			resp: `
 title
-
-message
 
 
 
@@ -80,15 +72,12 @@ message
 			name:     "case 3",
 			template: DefaultPlanTemplate,
 			value: CommonTemplate{
-				Title:   "title",
-				Message: "message",
-				Result:  "",
-				Body:    `This is a "body".`,
+				Title:  "title",
+				Result: "",
+				Body:   `This is a "body".`,
 			},
 			resp: `
 title
-
-message
 
 
 
@@ -103,15 +92,12 @@ message
 			template: DefaultPlanTemplate,
 			value: CommonTemplate{
 				Title:        "title",
-				Message:      "message",
 				Result:       "",
 				Body:         `This is a "body".`,
 				UseRawOutput: true,
 			},
 			resp: `
 title
-
-message
 
 
 
@@ -125,15 +111,12 @@ message
 			name:     "case 5",
 			template: "",
 			value: CommonTemplate{
-				Title:   "title",
-				Message: "message",
-				Result:  "",
-				Body:    "body",
+				Title:  "title",
+				Result: "",
+				Body:   "body",
 			},
 			resp: `
 title
-
-message
 
 
 
@@ -145,14 +128,13 @@ message
 		},
 		{
 			name:     "case 6",
-			template: `{{ .Title }}-{{ .Message }}-{{ .Result }}-{{ .Body }}`,
+			template: `{{ .Title }}-{{ .Result }}-{{ .Body }}`,
 			value: CommonTemplate{
-				Title:   "a",
-				Message: "b",
-				Result:  "c",
-				Body:    "d",
+				Title:  "a",
+				Result: "c",
+				Body:   "d",
 			},
-			resp: `a-b-c-d`,
+			resp: `a-c-d`,
 		},
 	}
 	for i, testCase := range testCases {
@@ -264,14 +246,13 @@ This plan contains resource delete operation. Please check the plan result very 
 		},
 		{
 			name:     "case 5",
-			template: `{{ .Title }}-{{ .Message }}-{{ .Result }}-{{ .Body }}`,
+			template: `{{ .Title }}-{{ .Result }}-{{ .Body }}`,
 			value: CommonTemplate{
-				Title:   "a",
-				Message: "b",
-				Result:  "c",
-				Body:    "d",
+				Title:  "a",
+				Result: "c",
+				Body:   "d",
 			},
-			resp: `a-b-c-d`,
+			resp: `a-c-d`,
 		},
 	}
 	for i, testCase := range testCases {
@@ -311,8 +292,6 @@ func TestApplyTemplateExecute(t *testing.T) {
 
 
 
-
-
 <details><summary>Details (Click me)</summary>
 
 <pre><code>
@@ -323,15 +302,12 @@ func TestApplyTemplateExecute(t *testing.T) {
 			name:     "case 1",
 			template: DefaultApplyTemplate,
 			value: CommonTemplate{
-				Title:   "title",
-				Message: "message",
-				Result:  "result",
-				Body:    "body",
+				Title:  "title",
+				Result: "result",
+				Body:   "body",
 			},
 			resp: `
 title
-
-message
 
 
 <pre><code>result
@@ -348,15 +324,12 @@ message
 			name:     "case 2",
 			template: DefaultApplyTemplate,
 			value: CommonTemplate{
-				Title:   "title",
-				Message: "message",
-				Result:  "",
-				Body:    "body",
+				Title:  "title",
+				Result: "",
+				Body:   "body",
 			},
 			resp: `
 title
-
-message
 
 
 
@@ -370,15 +343,12 @@ message
 			name:     "case 3",
 			template: "",
 			value: CommonTemplate{
-				Title:   "title",
-				Message: "message",
-				Result:  "",
-				Body:    "body",
+				Title:  "title",
+				Result: "",
+				Body:   "body",
 			},
 			resp: `
 title
-
-message
 
 
 
@@ -392,15 +362,12 @@ message
 			name:     "case 4",
 			template: "",
 			value: CommonTemplate{
-				Title:   "title",
-				Message: "message",
-				Result:  "",
-				Body:    `This is a "body".`,
+				Title:  "title",
+				Result: "",
+				Body:   `This is a "body".`,
 			},
 			resp: `
 title
-
-message
 
 
 
@@ -415,15 +382,12 @@ message
 			template: "",
 			value: CommonTemplate{
 				Title:        "title",
-				Message:      "message",
 				Result:       "",
 				Body:         `This is a "body".`,
 				UseRawOutput: true,
 			},
 			resp: `
 title
-
-message
 
 
 
@@ -435,14 +399,13 @@ message
 		},
 		{
 			name:     "case 6",
-			template: `{{ .Title }}-{{ .Message }}-{{ .Result }}-{{ .Body }}`,
+			template: `{{ .Title }}-{{ .Result }}-{{ .Body }}`,
 			value: CommonTemplate{
-				Title:   "a",
-				Message: "b",
-				Result:  "c",
-				Body:    "d",
+				Title:  "a",
+				Result: "c",
+				Body:   "d",
 			},
-			resp: `a-b-c-d`,
+			resp: `a-c-d`,
 		},
 	}
 	for i, testCase := range testCases {


### PR DESCRIPTION
We added more general option `-var` and template variable `Vars`, so the `message` opiton isn't needed.
We have never used `messsage` option and variable, so I decided to remove them.