### PR TITLE
fix: remove title and destroy-warning-title options and template variable ".Title"

### DIFF
--- a/COMPARED_WITH_TFNOTIFY.md
+++ b/COMPARED_WITH_TFNOTIFY.md
@@ -8,7 +8,8 @@ tfcmt isn't compatible with tfnotify.
   * [Remove `fmt` command](#breaking-change-remove-fmt-command)
   * [Configuration file name is changed](#breaking-change-configuration-file-name-is-changed)
   * [Command usage is changed](#breaking-change-command-usage-is-changed)
-  * [Remove --message option and template variable .Message](#breaking-change-remove---message-option-and-template-variable-message)
+  * [Remove --message and --destroy-warning-message option and template variable .Message](#breaking-change-remove---message-and---destroy-warning-message-option-and-template-variable-message)
+  * [Remove --title and --destroy-warning-title options and template variable .Title](#breaking-change-remove---title-and---destroy-warning-title-options-and-template-variable-title)
   * [Don't remove duplicate comments](#breaking-change-dont-remove-duplicate-comments)
   * [Change the behavior of deletion warning](#breaking-change-change-the-behavior-of-deletion-warning)
 * Features
@@ -91,10 +92,19 @@ tfcmt apply -- terraform apply
 
 By this change, tfcmt can handle the standard error output and exit code of the terraform command.
 
-## Breaking Change: Remove --message option and template variable .Message
+## Breaking Change: Remove --message and --destroy-warning-message option and template variable .Message
+
+[#40](https://github.com/suzuki-shunsuke/tfcmt/pull/40)
 
 We introduced more general option `-var` and template variable `.Vars`,
-so the `--message` option isn't needed.
+so the `--message` and `--destroy-warning-message` options aren't needed.
+
+## Breaking Change: Remove --title and --destroy-warning-title options and template variable .Title
+
+[#41](https://github.com/suzuki-shunsuke/tfcmt/pull/41)
+
+We introduced more general option `-var` and template variable `.Vars`,
+so the `--title` and `--destroy-warning-title` options aren't needed.
 
 ## Breaking Change: Don't remove duplicate comments
 
@@ -192,7 +202,7 @@ terraform:
   plan:
     when_parse_error:
       template: |
-      ## Plan Result <sup>[CI link]( {{ .Link }} )</sup>
+        ## Plan Result <sup>[CI link]( {{ .Link }} )</sup>
 
         :warning: It failed to parse the result. :warning:
 

--- a/COMPARED_WITH_TFNOTIFY.md
+++ b/COMPARED_WITH_TFNOTIFY.md
@@ -117,7 +117,7 @@ tfcmt posts only one comment whose template is `when_destroy.template`.
       label: "destroy"
       label_color: "d93f0b"  # red
       template: |
-        {{ .Title }}
+        ## Plan Result
 
         [CI link]( {{ .Link }} )
 
@@ -132,8 +132,6 @@ tfcmt posts only one comment whose template is `when_destroy.template`.
         <pre><code>{{ .Body }}
         </pre></code></details>
 ```
-
-And the default title of destroy warning is changed to `## :warning: Resource Deletion will happen :warning:`.
 
 ### Feature: Add template variables of changed resource paths
 
@@ -194,7 +192,7 @@ terraform:
   plan:
     when_parse_error:
       template: |
-        {{ .Title }} <sup>[CI link]( {{ .Link }} )</sup>
+      ## Plan Result <sup>[CI link]( {{ .Link }} )</sup>
 
         :warning: It failed to parse the result. :warning:
 
@@ -205,7 +203,7 @@ terraform:
   apply:
     when_parse_error:
       template: |
-        {{ .Title }} <sup>[CI link]( {{ .Link }} )</sup>
+        ## Apply Result <sup>[CI link]( {{ .Link }} )</sup>
 
         :warning: It failed to parse the result. :warning:
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,6 @@ The example settings of GitHub and GitHub Enterprise are as follows. Incidentall
 
 Placeholder | Usage
 ---|---
-`{{ .Title }}` | Like `## Plan result`
 `{{ .Result }}` | Matched result by parsing like `Plan: 1 to add` or `No changes`
 `{{ .Body }}` | The entire of Terraform execution result
 `{{ .Link }}` | The link of the build page on CI
@@ -102,7 +101,7 @@ notifier:
 terraform:
   plan:
     template: |
-      {{ .Title }} <sup>[CI link]( {{ .Link }} )</sup>
+      ## Plan Result <sup>[CI link]( {{ .Link }} )</sup>
       {{if .Result}}
       <pre><code>{{ .Result }}
       </pre></code>
@@ -113,7 +112,7 @@ terraform:
       </pre></code></details>
   apply:
     template: |
-      {{ .Title }}
+      ## Apply Result
       {{if .Result}}
       <pre><code>{{ .Result }}
       </pre></code>
@@ -133,7 +132,7 @@ terraform:
   # ...
   plan:
     template: |
-      {{ .Title }} <sup>[CI link]( {{ .Link }} )</sup>
+      ## Plan Result <sup>[CI link]( {{ .Link }} )</sup>
       {{if .Result}}
       <pre><code>{{ .Result }}
       </pre></code>
@@ -159,7 +158,7 @@ terraform:
   # ...
   plan:
     template: |
-      {{ .Title }} <sup>[CI link]( {{ .Link }} )</sup>
+      ## Plan Result <sup>[CI link]( {{ .Link }} )</sup>
       {{if .Result}}
       <pre><code>{{ .Result }}
       </pre></code>
@@ -196,7 +195,7 @@ terraform:
   # ...
   plan:
     template: |
-      {{ .Title }} <sup>[CI link]( {{ .Link }} )</sup>
+      ## Plan Result <sup>[CI link]( {{ .Link }} )</sup>
       {{if .Result}}
       ```
       {{ .Result }}
@@ -228,7 +227,7 @@ notifier:
 terraform:
   plan:
     template: |
-      {{ .Title }} <sup>[CI link]( {{ .Link }} )</sup>
+      ## Plan Result <sup>[CI link]( {{ .Link }} )</sup>
       {{if .Result}}
       <pre><code>{{ .Result }}
       </pre></code>
@@ -239,7 +238,7 @@ terraform:
       </pre></code></details>
   apply:
     template: |
-      {{ .Title }}
+      ## Apply Result
       {{if .Result}}
       <pre><code>{{ .Result }}
       </pre></code>

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -40,7 +40,7 @@ func TestLoadFile(t *testing.T) {
 						Template: "",
 					},
 					Plan: Plan{
-						Template:    "{{ .Title }}\n{{if .Result}}\n<pre><code>{{ .Result }}\n</pre></code>\n{{end}}\n<details><summary>Details (Click me)</summary>\n\n<pre><code>{{ .Body }}\n</pre></code></details>\n",
+						Template:    "## Plan Result\n{{if .Result}}\n<pre><code>{{ .Result }}\n</pre></code>\n{{end}}\n<details><summary>Details (Click me)</summary>\n\n<pre><code>{{ .Body }}\n</pre></code></details>\n",
 						WhenDestroy: WhenDestroy{},
 					},
 					Apply: Apply{
@@ -70,7 +70,7 @@ func TestLoadFile(t *testing.T) {
 						Template: "",
 					},
 					Plan: Plan{
-						Template: "{{ .Title }}\n{{if .Result}}\n<pre><code>{{ .Result }}\n</pre></code>\n{{end}}\n<details><summary>Details (Click me)</summary>\n\n<pre><code>{{ .Body }}\n</pre></code></details>\n",
+						Template: "## Plan Result\n{{if .Result}}\n<pre><code>{{ .Result }}\n</pre></code>\n{{end}}\n<details><summary>Details (Click me)</summary>\n\n<pre><code>{{ .Body }}\n</pre></code></details>\n",
 						WhenAddOrUpdateOnly: WhenAddOrUpdateOnly{
 							Label: "add-or-update",
 						},
@@ -112,7 +112,7 @@ func TestLoadFile(t *testing.T) {
 						Template: "",
 					},
 					Plan: Plan{
-						Template:    "{{ .Title }}\n{{if .Result}}\n<pre><code>{{ .Result }}\n</pre></code>\n{{end}}\n<details><summary>Details (Click me)</summary>\n\n<pre><code>{{ .Body }}\n</pre></code></details>\n",
+						Template:    "## Plan Result\n{{if .Result}}\n<pre><code>{{ .Result }}\n</pre></code>\n{{end}}\n<details><summary>Details (Click me)</summary>\n\n<pre><code>{{ .Body }}\n</pre></code></details>\n",
 						WhenDestroy: WhenDestroy{},
 					},
 					Apply: Apply{

--- a/example-use-raw-output.tfcmt.yaml
+++ b/example-use-raw-output.tfcmt.yaml
@@ -9,7 +9,7 @@ terraform:
   use_raw_output: true
   plan:
     template: |
-      {{ .Title }}
+      ## Plan Result
       {{if .Result}}
       <pre><code>{{ .Result }}
       </pre></code>

--- a/example-with-destroy-and-result-labels.tfcmt.yaml
+++ b/example-with-destroy-and-result-labels.tfcmt.yaml
@@ -8,7 +8,7 @@ notifier:
 terraform:
   plan:
     template: |
-      {{ .Title }}
+      ## Plan Result
       {{if .Result}}
       <pre><code>{{ .Result }}
       </pre></code>

--- a/example.tfcmt.yaml
+++ b/example.tfcmt.yaml
@@ -8,7 +8,7 @@ notifier:
 terraform:
   plan:
     template: |
-      {{ .Title }}
+      ## Plan Result
       {{if .Result}}
       <pre><code>{{ .Result }}
       </pre></code>

--- a/main.go
+++ b/main.go
@@ -109,11 +109,8 @@ func (t *tfcmt) getNotifier(ctx context.Context, ci CI) (notifier.Notifier, erro
 		Owner:   t.config.Notifier.Github.Repository.Owner,
 		Repo:    t.config.Notifier.Github.Repository.Name,
 		PR: github.PullRequest{
-			Revision:              ci.PR.Revision,
-			Number:                ci.PR.Number,
-			Title:                 t.context.String("title"),
-			DestroyWarningTitle:   t.context.String("destroy-warning-title"),
-			DestroyWarningMessage: t.context.String("destroy-warning-message"),
+			Revision: ci.PR.Revision,
+			Number:   ci.PR.Number,
 		},
 		CI:                     ci.URL,
 		Parser:                 t.parser,
@@ -189,31 +186,11 @@ func main() {
 			Name:   "plan",
 			Usage:  "Run terraform plan and post a comment to GitHub commit or pull request",
 			Action: cmdPlan,
-			Flags: []cli.Flag{
-				&cli.StringFlag{
-					Name:  "title, t",
-					Usage: "Specify the title to use for notification",
-				},
-				&cli.StringFlag{
-					Name:  "destroy-warning-title",
-					Usage: "Specify the title to use for destroy warning notification",
-				},
-				&cli.StringFlag{
-					Name:  "destroy-warning-message",
-					Usage: "Specify the message to use for destroy warning notification",
-				},
-			},
 		},
 		{
 			Name:   "apply",
 			Usage:  "Run terraform apply and post a comment to GitHub commit or pull request",
 			Action: cmdApply,
-			Flags: []cli.Flag{
-				&cli.StringFlag{
-					Name:  "title, t",
-					Usage: "Specify the title to use for notification",
-				},
-			},
 		},
 		{
 			Name:  "version",

--- a/notifier/github/client.go
+++ b/notifier/github/client.go
@@ -57,12 +57,8 @@ type Config struct {
 
 // PullRequest represents GitHub Pull Request metadata
 type PullRequest struct {
-	Revision              string
-	Title                 string
-	Message               string
-	Number                int
-	DestroyWarningTitle   string
-	DestroyWarningMessage string
+	Revision string
+	Number   int
 }
 
 type service struct {

--- a/notifier/github/github_test.go
+++ b/notifier/github/github_test.go
@@ -131,7 +131,6 @@ func newFakeConfig() Config {
 		PR: PullRequest{
 			Revision: "abcd",
 			Number:   1,
-			Message:  "message",
 		},
 		Parser:   terraform.NewPlanParser(),
 		Template: terraform.NewPlanTemplate(terraform.DefaultPlanTemplate),

--- a/notifier/github/notify.go
+++ b/notifier/github/notify.go
@@ -102,7 +102,6 @@ func (g *NotifyService) Notify(ctx context.Context, param notifier.ParamExec) (i
 	}
 
 	template.SetValue(terraform.CommonTemplate{
-		Title:             cfg.PR.Title,
 		Result:            result.Result,
 		Body:              body,
 		Link:              cfg.CI,

--- a/notifier/github/notify_test.go
+++ b/notifier/github/notify_test.go
@@ -27,7 +27,6 @@ func TestNotifyNotify(t *testing.T) {
 				PR: PullRequest{
 					Revision: "abcd",
 					Number:   1,
-					Message:  "message",
 				},
 				Parser:             terraform.NewPlanParser(),
 				Template:           terraform.NewPlanTemplate(terraform.DefaultPlanTemplate),
@@ -50,7 +49,6 @@ func TestNotifyNotify(t *testing.T) {
 				PR: PullRequest{
 					Revision: "",
 					Number:   0,
-					Message:  "message",
 				},
 				Parser:             terraform.NewPlanParser(),
 				Template:           terraform.NewPlanTemplate(terraform.DefaultPlanTemplate),
@@ -73,7 +71,6 @@ func TestNotifyNotify(t *testing.T) {
 				PR: PullRequest{
 					Revision: "",
 					Number:   1,
-					Message:  "message",
 				},
 				Parser:             terraform.NewPlanParser(),
 				Template:           terraform.NewPlanTemplate(terraform.DefaultPlanTemplate),
@@ -96,7 +93,6 @@ func TestNotifyNotify(t *testing.T) {
 				PR: PullRequest{
 					Revision: "",
 					Number:   1,
-					Message:  "message",
 				},
 				Parser:             terraform.NewPlanParser(),
 				Template:           terraform.NewPlanTemplate(terraform.DefaultPlanTemplate),
@@ -119,7 +115,6 @@ func TestNotifyNotify(t *testing.T) {
 				PR: PullRequest{
 					Revision: "revision-revision",
 					Number:   0,
-					Message:  "message",
 				},
 				Parser:             terraform.NewPlanParser(),
 				Template:           terraform.NewPlanTemplate(terraform.DefaultPlanTemplate),
@@ -143,7 +138,6 @@ func TestNotifyNotify(t *testing.T) {
 				PR: PullRequest{
 					Revision: "",
 					Number:   1,
-					Message:  "message",
 				},
 				Parser:                 terraform.NewPlanParser(),
 				Template:               terraform.NewPlanTemplate(terraform.DefaultPlanTemplate),
@@ -169,7 +163,6 @@ func TestNotifyNotify(t *testing.T) {
 				PR: PullRequest{
 					Revision: "",
 					Number:   1,
-					Message:  "message",
 				},
 				Parser:             terraform.NewPlanParser(),
 				Template:           terraform.NewPlanTemplate(terraform.DefaultPlanTemplate),
@@ -198,7 +191,6 @@ func TestNotifyNotify(t *testing.T) {
 				PR: PullRequest{
 					Revision: "",
 					Number:   1,
-					Message:  "message",
 				},
 				Parser:                 terraform.NewPlanParser(),
 				Template:               terraform.NewPlanTemplate(terraform.DefaultPlanTemplate),
@@ -223,7 +215,6 @@ func TestNotifyNotify(t *testing.T) {
 				PR: PullRequest{
 					Revision: "revision",
 					Number:   0, // For apply, it is always 0
-					Message:  "message",
 				},
 				Parser:             terraform.NewApplyParser(),
 				Template:           terraform.NewApplyTemplate(terraform.DefaultApplyTemplate),
@@ -247,7 +238,6 @@ func TestNotifyNotify(t *testing.T) {
 				PR: PullRequest{
 					Revision: "Merge pull request #123 from suzuki-shunsuke/tfcmt",
 					Number:   0, // For apply, it is always 0
-					Message:  "message",
 				},
 				Parser:             terraform.NewApplyParser(),
 				Template:           terraform.NewApplyTemplate(terraform.DefaultApplyTemplate),

--- a/terraform/template.go
+++ b/terraform/template.go
@@ -9,15 +9,9 @@ import (
 )
 
 const (
-	// DefaultPlanTitle is a default title for terraform plan
-	DefaultPlanTitle = "## Plan result"
-	// DefaultDestroyWarningTitle is a default title of destroy warning
-	DefaultDestroyWarningTitle = "## :warning: Resource Deletion will happen :warning:"
-	// DefaultApplyTitle is a default title for terraform apply
-	DefaultApplyTitle = "## Apply result"
-
-	defaultTemplate = `
-{{ .Title }}
+	// DefaultPlanTemplate is a default template for terraform plan
+	DefaultPlanTemplate = `
+## Plan Result
 
 {{if .Result}}
 <pre><code>{{ .Result }}
@@ -34,14 +28,28 @@ const (
 * {{. -}}
 {{- end}}{{end}}`
 
-	// DefaultPlanTemplate is a default template for terraform plan
-	DefaultPlanTemplate = defaultTemplate
 	// DefaultApplyTemplate is a default template for terraform apply
-	DefaultApplyTemplate = defaultTemplate
+	DefaultApplyTemplate = `
+## Apply Result
+
+{{if .Result}}
+<pre><code>{{ .Result }}
+</code></pre>
+{{end}}
+
+<details><summary>Details (Click me)</summary>
+
+<pre><code>{{ .Body }}
+</code></pre></details>
+{{if .ErrorMessages}}
+## :warning: Errors
+{{range .ErrorMessages}}
+* {{. -}}
+{{- end}}{{end}}`
 
 	// DefaultDestroyWarningTemplate is a default template for terraform plan
 	DefaultDestroyWarningTemplate = `
-{{ .Title }}
+## :warning: Plan Result: Resource Deletion will happen :warning:
 
 This plan contains resource delete operation. Please check the plan result very carefully!
 
@@ -51,8 +59,19 @@ This plan contains resource delete operation. Please check the plan result very 
 {{end}}
 `
 
-	DefaultParseErrorTemplate = `
-{{ .Title }}
+	DefaultPlanParseErrorTemplate = `
+## Plan Result
+
+It failed to parse the result.
+
+<details><summary>Details (Click me)</summary>
+
+<pre><code>{{ .CombinedOutput }}
+</code></pre></details>
+`
+
+	DefaultApplyParseErrorTemplate = `
+## Apply Result
 
 It failed to parse the result.
 
@@ -65,7 +84,6 @@ It failed to parse the result.
 
 // CommonTemplate represents template entities
 type CommonTemplate struct {
-	Title             string
 	Result            string
 	Body              string
 	Link              string
@@ -84,9 +102,7 @@ type CommonTemplate struct {
 
 // Template is a default template for terraform commands
 type Template struct {
-	Template     string
-	defaultTitle string
-
+	Template string
 	CommonTemplate
 }
 
@@ -96,8 +112,7 @@ func NewPlanTemplate(template string) *Template {
 		template = DefaultPlanTemplate
 	}
 	return &Template{
-		Template:     template,
-		defaultTitle: DefaultPlanTitle,
+		Template: template,
 	}
 }
 
@@ -107,8 +122,7 @@ func NewDestroyWarningTemplate(template string) *Template {
 		template = DefaultDestroyWarningTemplate
 	}
 	return &Template{
-		Template:     template,
-		defaultTitle: DefaultDestroyWarningTitle,
+		Template: template,
 	}
 }
 
@@ -118,28 +132,25 @@ func NewApplyTemplate(template string) *Template {
 		template = DefaultApplyTemplate
 	}
 	return &Template{
-		Template:     template,
-		defaultTitle: DefaultApplyTitle,
+		Template: template,
 	}
 }
 
 func NewPlanParseErrorTemplate(template string) *Template {
 	if template == "" {
-		template = DefaultParseErrorTemplate
+		template = DefaultPlanParseErrorTemplate
 	}
 	return &Template{
-		Template:     template,
-		defaultTitle: DefaultPlanTitle,
+		Template: template,
 	}
 }
 
 func NewApplyParseErrorTemplate(template string) *Template {
 	if template == "" {
-		template = DefaultParseErrorTemplate
+		template = DefaultApplyParseErrorTemplate
 	}
 	return &Template{
-		Template:     template,
-		defaultTitle: DefaultApplyTitle,
+		Template: template,
 	}
 }
 
@@ -170,7 +181,6 @@ func generateOutput(kind, template string, data map[string]interface{}, useRawOu
 // Execute binds the execution result of terraform command into template
 func (t *Template) Execute() (string, error) {
 	data := map[string]interface{}{
-		"Title":             t.Title,
 		"Result":            t.Result,
 		"Body":              t.Body,
 		"Link":              t.Link,
@@ -196,8 +206,5 @@ func (t *Template) Execute() (string, error) {
 
 // SetValue sets template entities to CommonTemplate
 func (t *Template) SetValue(ct CommonTemplate) {
-	if ct.Title == "" {
-		ct.Title = t.defaultTitle
-	}
 	t.CommonTemplate = ct
 }

--- a/terraform/template_test.go
+++ b/terraform/template_test.go
@@ -17,7 +17,7 @@ func TestPlanTemplateExecute(t *testing.T) {
 			template: DefaultPlanTemplate,
 			value:    CommonTemplate{},
 			resp: `
-## Plan result
+## Plan Result
 
 
 
@@ -31,12 +31,11 @@ func TestPlanTemplateExecute(t *testing.T) {
 			name:     "case 1",
 			template: DefaultPlanTemplate,
 			value: CommonTemplate{
-				Title:  "title",
 				Result: "result",
 				Body:   "body",
 			},
 			resp: `
-title
+## Plan Result
 
 
 <pre><code>result
@@ -53,12 +52,11 @@ title
 			name:     "case 2",
 			template: DefaultPlanTemplate,
 			value: CommonTemplate{
-				Title:  "title",
 				Result: "",
 				Body:   "body",
 			},
 			resp: `
-title
+## Plan Result
 
 
 
@@ -72,12 +70,11 @@ title
 			name:     "case 3",
 			template: DefaultPlanTemplate,
 			value: CommonTemplate{
-				Title:  "title",
 				Result: "",
 				Body:   `This is a "body".`,
 			},
 			resp: `
-title
+## Plan Result
 
 
 
@@ -91,13 +88,12 @@ title
 			name:     "case 4",
 			template: DefaultPlanTemplate,
 			value: CommonTemplate{
-				Title:        "title",
 				Result:       "",
 				Body:         `This is a "body".`,
 				UseRawOutput: true,
 			},
 			resp: `
-title
+## Plan Result
 
 
 
@@ -111,12 +107,11 @@ title
 			name:     "case 5",
 			template: "",
 			value: CommonTemplate{
-				Title:  "title",
 				Result: "",
 				Body:   "body",
 			},
 			resp: `
-title
+## Plan Result
 
 
 
@@ -128,13 +123,12 @@ title
 		},
 		{
 			name:     "case 6",
-			template: `{{ .Title }}-{{ .Result }}-{{ .Body }}`,
+			template: `{{ .Result }}-{{ .Body }}`,
 			value: CommonTemplate{
-				Title:  "a",
 				Result: "c",
 				Body:   "d",
 			},
-			resp: `a-c-d`,
+			resp: `c-d`,
 		},
 	}
 	for i, testCase := range testCases {
@@ -170,7 +164,7 @@ func TestDestroyWarningTemplateExecute(t *testing.T) {
 			template: DefaultDestroyWarningTemplate,
 			value:    CommonTemplate{},
 			resp: `
-## :warning: Resource Deletion will happen :warning:
+## :warning: Plan Result: Resource Deletion will happen :warning:
 
 This plan contains resource delete operation. Please check the plan result very carefully!
 
@@ -181,11 +175,10 @@ This plan contains resource delete operation. Please check the plan result very 
 			name:     "case 1",
 			template: DefaultDestroyWarningTemplate,
 			value: CommonTemplate{
-				Title:  "title",
 				Result: `This is a "result".`,
 			},
 			resp: `
-title
+## :warning: Plan Result: Resource Deletion will happen :warning:
 
 This plan contains resource delete operation. Please check the plan result very carefully!
 
@@ -199,12 +192,11 @@ This plan contains resource delete operation. Please check the plan result very 
 			name:     "case 2",
 			template: DefaultDestroyWarningTemplate,
 			value: CommonTemplate{
-				Title:        "title",
 				Result:       `This is a "result".`,
 				UseRawOutput: true,
 			},
 			resp: `
-title
+## :warning: Plan Result: Resource Deletion will happen :warning:
 
 This plan contains resource delete operation. Please check the plan result very carefully!
 
@@ -218,11 +210,10 @@ This plan contains resource delete operation. Please check the plan result very 
 			name:     "case 3",
 			template: DefaultDestroyWarningTemplate,
 			value: CommonTemplate{
-				Title:  "title",
 				Result: "",
 			},
 			resp: `
-title
+## :warning: Plan Result: Resource Deletion will happen :warning:
 
 This plan contains resource delete operation. Please check the plan result very carefully!
 
@@ -233,11 +224,10 @@ This plan contains resource delete operation. Please check the plan result very 
 			name:     "case 4",
 			template: "",
 			value: CommonTemplate{
-				Title:  "title",
 				Result: "",
 			},
 			resp: `
-title
+## :warning: Plan Result: Resource Deletion will happen :warning:
 
 This plan contains resource delete operation. Please check the plan result very carefully!
 
@@ -246,13 +236,12 @@ This plan contains resource delete operation. Please check the plan result very 
 		},
 		{
 			name:     "case 5",
-			template: `{{ .Title }}-{{ .Result }}-{{ .Body }}`,
+			template: `{{ .Result }}-{{ .Body }}`,
 			value: CommonTemplate{
-				Title:  "a",
 				Result: "c",
 				Body:   "d",
 			},
-			resp: `a-c-d`,
+			resp: `c-d`,
 		},
 	}
 	for i, testCase := range testCases {
@@ -288,7 +277,7 @@ func TestApplyTemplateExecute(t *testing.T) {
 			template: DefaultApplyTemplate,
 			value:    CommonTemplate{},
 			resp: `
-## Apply result
+## Apply Result
 
 
 
@@ -302,12 +291,11 @@ func TestApplyTemplateExecute(t *testing.T) {
 			name:     "case 1",
 			template: DefaultApplyTemplate,
 			value: CommonTemplate{
-				Title:  "title",
 				Result: "result",
 				Body:   "body",
 			},
 			resp: `
-title
+## Apply Result
 
 
 <pre><code>result
@@ -324,12 +312,11 @@ title
 			name:     "case 2",
 			template: DefaultApplyTemplate,
 			value: CommonTemplate{
-				Title:  "title",
 				Result: "",
 				Body:   "body",
 			},
 			resp: `
-title
+## Apply Result
 
 
 
@@ -343,12 +330,11 @@ title
 			name:     "case 3",
 			template: "",
 			value: CommonTemplate{
-				Title:  "title",
 				Result: "",
 				Body:   "body",
 			},
 			resp: `
-title
+## Apply Result
 
 
 
@@ -362,12 +348,11 @@ title
 			name:     "case 4",
 			template: "",
 			value: CommonTemplate{
-				Title:  "title",
 				Result: "",
 				Body:   `This is a "body".`,
 			},
 			resp: `
-title
+## Apply Result
 
 
 
@@ -381,13 +366,12 @@ title
 			name:     "case 5",
 			template: "",
 			value: CommonTemplate{
-				Title:        "title",
 				Result:       "",
 				Body:         `This is a "body".`,
 				UseRawOutput: true,
 			},
 			resp: `
-title
+## Apply Result
 
 
 
@@ -399,13 +383,12 @@ title
 		},
 		{
 			name:     "case 6",
-			template: `{{ .Title }}-{{ .Result }}-{{ .Body }}`,
+			template: `{{ .Result }}-{{ .Body }}`,
 			value: CommonTemplate{
-				Title:  "a",
 				Result: "c",
 				Body:   "d",
 			},
-			resp: `a-c-d`,
+			resp: `c-d`,
 		},
 	}
 	for i, testCase := range testCases {


### PR DESCRIPTION
BREAKING CHANGE: `--title` and `--destroy-warning-title` options and template variable "title" are removed

We introduced more general option `-var` and template variable `.Vars`,
so the `--title` and `--destroy-warning-title` options aren't needed.