### PR TITLE
feat: add the variable "target" to default template and default label name

### DIFF
--- a/COMPARED_WITH_TFNOTIFY.md
+++ b/COMPARED_WITH_TFNOTIFY.md
@@ -304,6 +304,11 @@ This feature is useful especially for Monorepo.
 tfcmt supports to pass variables to template by `-var <name>:<value>` options.
 We can access the variable in the template by `{{.Vars.<variable name>}}`.
 
+The variable `target` has a special meaning.
+This variable is used at the default template and default label name.
+This is useful for Monorepo. By setting `target`, we can distinguish the comment and label of each service.
+When this variable isn't set, this is just ignored.
+
 ## Feature: Add template variables
 
 * Stdout: standard output of terraform command

--- a/main.go
+++ b/main.go
@@ -70,6 +70,11 @@ func (t *tfcmt) renderGitHubLabels() (github.ResultLabels, error) {
 		PlanErrorLabelColor:   t.config.Terraform.Plan.WhenPlanError.Color,
 	}
 
+	target, ok := t.config.Vars["target"]
+	if !ok {
+		target = ""
+	}
+
 	if labels.AddOrUpdateLabelColor == "" {
 		labels.AddOrUpdateLabelColor = "1d76db" // blue
 	}
@@ -81,7 +86,11 @@ func (t *tfcmt) renderGitHubLabels() (github.ResultLabels, error) {
 	}
 
 	if t.config.Terraform.Plan.WhenAddOrUpdateOnly.Label == "" {
-		labels.AddOrUpdateLabel = "add-or-update"
+		if target == "" {
+			labels.AddOrUpdateLabel = "add-or-update"
+		} else {
+			labels.AddOrUpdateLabel = target + "/add-or-update"
+		}
 	} else {
 		addOrUpdateLabel, err := t.renderTemplate(t.config.Terraform.Plan.WhenAddOrUpdateOnly.Label)
 		if err != nil {
@@ -91,7 +100,11 @@ func (t *tfcmt) renderGitHubLabels() (github.ResultLabels, error) {
 	}
 
 	if t.config.Terraform.Plan.WhenDestroy.Label == "" {
-		labels.DestroyLabel = "destroy"
+		if target == "" {
+			labels.DestroyLabel = "destroy"
+		} else {
+			labels.DestroyLabel = target + "/destroy"
+		}
 	} else {
 		destroyLabel, err := t.renderTemplate(t.config.Terraform.Plan.WhenDestroy.Label)
 		if err != nil {
@@ -101,7 +114,11 @@ func (t *tfcmt) renderGitHubLabels() (github.ResultLabels, error) {
 	}
 
 	if t.config.Terraform.Plan.WhenNoChanges.Label == "" {
-		labels.NoChangesLabel = "no-changes"
+		if target == "" {
+			labels.NoChangesLabel = "no-changes"
+		} else {
+			labels.NoChangesLabel = "/no-changes"
+		}
 	} else {
 		nochangesLabel, err := t.renderTemplate(t.config.Terraform.Plan.WhenNoChanges.Label)
 		if err != nil {

--- a/terraform/template.go
+++ b/terraform/template.go
@@ -12,7 +12,7 @@ import (
 const (
 	// DefaultPlanTemplate is a default template for terraform plan
 	DefaultPlanTemplate = `
-## Plan Result
+## Plan Result{{if .Vars.target}} ({{.Vars.target}}){{end}}
 
 [CI link]({{ .Link }})
 
@@ -40,7 +40,7 @@ const (
 
 	// DefaultApplyTemplate is a default template for terraform apply
 	DefaultApplyTemplate = `
-## Apply Result
+## Apply Result{{if .Vars.target}} ({{.Vars.target}}){{end}}
 
 [CI link]({{ .Link }})
 
@@ -60,7 +60,7 @@ const (
 
 	// DefaultDestroyWarningTemplate is a default template for terraform plan
 	DefaultDestroyWarningTemplate = `
-## :warning: Plan Result: Resource Deletion will happen :warning:
+## :warning: Plan Result{{if .Vars.target}} ({{.Vars.target}}){{end}}: Resource Deletion will happen :warning:
 
 [CI link]({{ .Link }})
 
@@ -93,7 +93,7 @@ This plan contains resource delete operation. Please check the plan result very 
 `
 
 	DefaultPlanParseErrorTemplate = `
-## Plan Result
+## Plan Result{{if .Vars.target}} ({{.Vars.target}}){{end}}
 
 [CI link]({{ .Link }})
 
@@ -105,7 +105,7 @@ It failed to parse the result.
 `
 
 	DefaultApplyParseErrorTemplate = `
-## Apply Result
+## Apply Result{{if .Vars.target}} ({{.Vars.target}}){{end}}
 
 [CI link]({{ .Link }})
 


### PR DESCRIPTION
BREAKING CHANGE: the variable "target" is added to default template and default label name

This is useful for Monorepo. By setting `target`, we can distinguish the comment and label of each service.
When this variable isn't set, this is just ignored.