### PR TITLE
feat: add templates config

### DIFF
--- a/COMPARED_WITH_TFNOTIFY.md
+++ b/COMPARED_WITH_TFNOTIFY.md
@@ -319,7 +319,7 @@ When this variable isn't set, this is just ignored.
 * Vars: variables which are passed by `-var` option
 * ErrorMessages: a list of error messages which occur in tfcmt
 
-## Feature: Add templates configuration
+## Feature: Add templates configuration and builtin templates
 
 [#50](https://github.com/suzuki-shunsuke/tfcmt/issues/50) [#51](https://github.com/suzuki-shunsuke/tfcmt/pull/51)
 
@@ -333,6 +333,14 @@ terraform:
     template: |
       {{template "title" .}}
 ```
+
+The following builtin templates are defined. We can override them.
+
+* plan_title
+* apply_title
+* result
+* updated_resources
+* deletion_warning
 
 ## Feature: Don't recreate labels
 

--- a/COMPARED_WITH_TFNOTIFY.md
+++ b/COMPARED_WITH_TFNOTIFY.md
@@ -24,6 +24,7 @@ tfcmt isn't compatible with tfnotify.
   * Support template functions [sprig](http://masterminds.github.io/sprig/)
   * [Support to pass variables by -var option](#feature-support-to-pass-variables-by--var-option)
   * [Add template variables](#feature-add-template-variables)
+  * [Add templates configuration](#feature-add-templates-configuration)
   * [Don't recreate labels](#feature-dont-recreate-labels)
   * [--version option and `version` command](#feature---version-option-and-version-command)
 * Fixes
@@ -317,6 +318,21 @@ When this variable isn't set, this is just ignored.
 * ExitCode: exit code of terraform command
 * Vars: variables which are passed by `-var` option
 * ErrorMessages: a list of error messages which occur in tfcmt
+
+## Feature: Add templates configuration
+
+[#50](https://github.com/suzuki-shunsuke/tfcmt/issues/50) [#51](https://github.com/suzuki-shunsuke/tfcmt/pull/51)
+
+ex.
+
+```yaml
+templates:
+  title: "## Plan Result ({{.Vars.target}})"
+terraform:
+  plan:
+    template: |
+      {{template "title" .}}
+```
 
 ## Feature: Don't recreate labels
 

--- a/config/config.go
+++ b/config/config.go
@@ -17,6 +17,7 @@ type Config struct {
 	Notifier  Notifier          `yaml:"notifier"`
 	Terraform Terraform         `yaml:"terraform"`
 	Vars      map[string]string `yaml:"-"`
+	Templates map[string]string
 
 	path string
 }

--- a/main.go
+++ b/main.go
@@ -162,6 +162,7 @@ func (t *tfcmt) getNotifier(ctx context.Context, ci CI) (notifier.Notifier, erro
 		ParseErrorTemplate:     t.parseErrorTemplate,
 		ResultLabels:           labels,
 		Vars:                   t.config.Vars,
+		Templates:              t.config.Templates,
 	})
 	if err != nil {
 		return nil, err

--- a/notifier/github/client.go
+++ b/notifier/github/client.go
@@ -52,6 +52,7 @@ type Config struct {
 	// ResultLabels is a set of labels to apply depending on the plan result
 	ResultLabels ResultLabels
 	Vars         map[string]string
+	Templates    map[string]string
 }
 
 // PullRequest represents GitHub Pull Request metadata

--- a/notifier/github/notify.go
+++ b/notifier/github/notify.go
@@ -50,6 +50,7 @@ func (g *NotifyService) Notify(ctx context.Context, param notifier.ParamExec) (i
 		Link:              cfg.CI,
 		UseRawOutput:      cfg.UseRawOutput,
 		Vars:              cfg.Vars,
+		Templates:         cfg.Templates,
 		Stdout:            param.Stdout,
 		Stderr:            param.Stderr,
 		CombinedOutput:    param.CombinedOutput,

--- a/terraform/template.go
+++ b/terraform/template.go
@@ -126,6 +126,7 @@ type CommonTemplate struct {
 	Link              string
 	UseRawOutput      bool
 	Vars              map[string]string
+	Templates         map[string]string
 	Stdout            string
 	Stderr            string
 	CombinedOutput    string
@@ -250,7 +251,7 @@ func (t *Template) Execute() (string, error) {
 		"ReplacedResources": t.ReplacedResources,
 	}
 
-	resp, err := generateOutput("default", t.Template, data, t.UseRawOutput)
+	resp, err := generateOutput("default", addTemplates(t.Template, t.Templates), data, t.UseRawOutput)
 	if err != nil {
 		return "", err
 	}
@@ -261,4 +262,11 @@ func (t *Template) Execute() (string, error) {
 // SetValue sets template entities to CommonTemplate
 func (t *Template) SetValue(ct CommonTemplate) {
 	t.CommonTemplate = ct
+}
+
+func addTemplates(tpl string, templates map[string]string) string {
+	for k, v := range templates {
+		tpl += `{{define "` + k + `"}}` + v + "{{end}}"
+	}
+	return tpl
 }

--- a/terraform/template.go
+++ b/terraform/template.go
@@ -12,23 +12,12 @@ import (
 const (
 	// DefaultPlanTemplate is a default template for terraform plan
 	DefaultPlanTemplate = `
-## Plan Result{{if .Vars.target}} ({{.Vars.target}}){{end}}
+{{template "plan_title" .}}
 
 [CI link]({{ .Link }})
 
-{{if .Result}}
-<pre><code>{{ .Result }}
-</code></pre>
-{{end}}
-{{if .CreatedResources}}
-* Create
-{{- range .CreatedResources}}
-  * {{.}}
-{{- end}}{{end}}{{if .UpdatedResources}}
-* Update
-{{- range .UpdatedResources}}
-  * {{.}}
-{{- end}}{{end}}
+{{template "result" .}}
+{{template "updated_resources" .}}
 <details><summary>Details (Click me)</summary>
 {{wrapCode .Body}}
 </details>
@@ -40,14 +29,11 @@ const (
 
 	// DefaultApplyTemplate is a default template for terraform apply
 	DefaultApplyTemplate = `
-## Apply Result{{if .Vars.target}} ({{.Vars.target}}){{end}}
+{{template "apply_title" .}}
 
 [CI link]({{ .Link }})
 
-{{if .Result}}
-<pre><code>{{ .Result }}
-</code></pre>
-{{end}}
+{{template "result" .}}
 
 <details><summary>Details (Click me)</summary>
 {{wrapCode .Body}}
@@ -60,42 +46,21 @@ const (
 
 	// DefaultDestroyWarningTemplate is a default template for terraform plan
 	DefaultDestroyWarningTemplate = `
-## Plan Result{{if .Vars.target}} ({{.Vars.target}}){{end}}
+{{template "plan_title" .}}
 
 [CI link]({{ .Link }})
 
-### :warning: Resource Deletion will happen :warning:
+{{template "deletion_warning" .}}
+{{template "result" .}}
 
-This plan contains resource delete operation. Please check the plan result very carefully!
-
-{{if .Result}}
-<pre><code>{{ .Result }}
-</code></pre>
-{{end}}
-{{if .CreatedResources}}
-* Create
-{{- range .CreatedResources}}
-  * {{.}}
-{{- end}}{{end}}{{if .UpdatedResources}}
-* Update
-{{- range .UpdatedResources}}
-  * {{.}}
-{{- end}}{{end}}{{if .DeletedResources}}
-* Delete
-{{- range .DeletedResources}}
-  * {{.}}
-{{- end}}{{end}}{{if .ReplacedResources}}
-* Replace
-{{- range .ReplacedResources}}
-  * {{.}}
-{{- end}}{{end}}
+{{template "updated_resources" .}}
 <details><summary>Details (Click me)</summary>
 {{wrapCode .Body}}
 </details>
 `
 
 	DefaultPlanParseErrorTemplate = `
-## Plan Result{{if .Vars.target}} ({{.Vars.target}}){{end}}
+{{template "plan_title" .}}
 
 [CI link]({{ .Link }})
 
@@ -251,7 +216,36 @@ func (t *Template) Execute() (string, error) {
 		"ReplacedResources": t.ReplacedResources,
 	}
 
-	resp, err := generateOutput("default", addTemplates(t.Template, t.Templates), data, t.UseRawOutput)
+	templates := map[string]string{
+		"plan_title":  "## Plan Result{{if .Vars.target}} ({{.Vars.target}}){{end}}",
+		"apply_title": "## Apply Result{{if .Vars.target}} ({{.Vars.target}}){{end}}",
+		"result":      "{{if .Result}}<pre><code>{{ .Result }}</code></pre>{{end}}",
+		"updated_resources": `{{if .CreatedResources}}
+* Create
+{{- range .CreatedResources}}
+  * {{.}}
+{{- end}}{{end}}{{if .UpdatedResources}}
+* Update
+{{- range .UpdatedResources}}
+  * {{.}}
+{{- end}}{{end}}{{if .DeletedResources}}
+* Delete
+{{- range .DeletedResources}}
+  * {{.}}
+{{- end}}{{end}}{{if .ReplacedResources}}
+* Replace
+{{- range .ReplacedResources}}
+  * {{.}}
+{{- end}}{{end}}`,
+		"deletion_warning": `### :warning: Resource Deletion will happen :warning:
+This plan contains resource delete operation. Please check the plan result very carefully!`,
+	}
+
+	for k, v := range t.Templates {
+		templates[k] = v
+	}
+
+	resp, err := generateOutput("default", addTemplates(t.Template, templates), data, t.UseRawOutput)
 	if err != nil {
 		return "", err
 	}

--- a/terraform/template_test.go
+++ b/terraform/template_test.go
@@ -44,10 +44,7 @@ func TestPlanTemplateExecute(t *testing.T) {
 
 [CI link]()
 
-
-<pre><code>result
-</code></pre>
-
+<pre><code>result</code></pre>
 
 <details><summary>Details (Click me)</summary>
 
@@ -199,7 +196,6 @@ func TestDestroyWarningTemplateExecute(t *testing.T) {
 [CI link]()
 
 ### :warning: Resource Deletion will happen :warning:
-
 This plan contains resource delete operation. Please check the plan result very carefully!
 
 
@@ -225,12 +221,8 @@ This plan contains resource delete operation. Please check the plan result very 
 [CI link]()
 
 ### :warning: Resource Deletion will happen :warning:
-
 This plan contains resource delete operation. Please check the plan result very carefully!
-
-
-<pre><code>This is a &#34;result&#34;.
-</code></pre>
+<pre><code>This is a &#34;result&#34;.</code></pre>
 
 
 <details><summary>Details (Click me)</summary>
@@ -255,12 +247,8 @@ This plan contains resource delete operation. Please check the plan result very 
 [CI link]()
 
 ### :warning: Resource Deletion will happen :warning:
-
 This plan contains resource delete operation. Please check the plan result very carefully!
-
-
-<pre><code>This is a "result".
-</code></pre>
+<pre><code>This is a "result".</code></pre>
 
 
 <details><summary>Details (Click me)</summary>
@@ -284,7 +272,6 @@ This plan contains resource delete operation. Please check the plan result very 
 [CI link]()
 
 ### :warning: Resource Deletion will happen :warning:
-
 This plan contains resource delete operation. Please check the plan result very carefully!
 
 
@@ -310,7 +297,6 @@ This plan contains resource delete operation. Please check the plan result very 
 [CI link]()
 
 ### :warning: Resource Deletion will happen :warning:
-
 This plan contains resource delete operation. Please check the plan result very carefully!
 
 
@@ -394,10 +380,7 @@ func TestApplyTemplateExecute(t *testing.T) {
 
 [CI link]()
 
-
-<pre><code>result
-</code></pre>
-
+<pre><code>result</code></pre>
 
 <details><summary>Details (Click me)</summary>
 


### PR DESCRIPTION
Close #50 

ex.

```yaml
templates:
  title: "## Plan Result ({{.Vars.target}})"
terraform:
  plan:
    template: |
      {{template "title" .}}
```

The following builtin templates are defined. We can override them.

* plan_title
* apply_title
* result
* updated_resources
* deletion_warning