### PR TITLE
feat: add command-line options about ci

### DIFF
--- a/COMPARED_WITH_TFNOTIFY.md
+++ b/COMPARED_WITH_TFNOTIFY.md
@@ -26,6 +26,7 @@ tfcmt isn't compatible with tfnotify.
   * [Add template variables](#feature-add-template-variables)
   * [Add templates configuration](#feature-add-templates-configuration)
   * [Add template functions](#feature-add-template-functions)
+  * [Add command-line options about CI](#feature-add-command-line-options-about-ci)
   * [Don't recreate labels](#feature-dont-recreate-labels)
   * [--version option and `version` command](#feature---version-option-and-version-command)
 * Fixes
@@ -354,6 +355,23 @@ The following builtin templates are defined. We can override them.
 
 `wrapCode` wraps a test with <code>\`\`\`</code> or `<pre><code>`.
 If the text includes <code>\`\`\`</code>, the text wraps with `<pre><code>`, otherwise the text wraps with <code>\`\`\`</code> and the text isn't HTML escaped.
+
+## Feature: Add command-line options about CI
+
+* -owner
+* -repo
+* -pr
+* -sha
+* -build-url
+
+mercari/tfnotify gets these parameters from only environment variables, so we don't use mercari/tfnotify on the platform which mercari/tfnotify doesn't support.
+On the other hand, tfcmt supports to specify these parameters by command-line options, so we can use tfcmt anywhere.
+
+ex.
+
+```
+$ tfcmt -owner suzuki-shunsuke -repo tfcmt -pr 3 -- terraform plan
+```
 
 ## Feature: Don't recreate labels
 

--- a/config/config.go
+++ b/config/config.go
@@ -115,7 +115,7 @@ func (cfg *Config) LoadFile(path string) error {
 func (cfg *Config) Validation() error {
 	switch strings.ToLower(cfg.CI) {
 	case "":
-		return errors.New("ci: need to be set")
+		break
 	case "circleci":
 		// ok pattern
 	case "codebuild":
@@ -127,32 +127,13 @@ func (cfg *Config) Validation() error {
 	default:
 		return fmt.Errorf("%s: not supported yet", cfg.CI)
 	}
-	if cfg.isDefinedGithub() {
-		if cfg.Notifier.Github.Repository.Owner == "" {
-			return errors.New("repository owner is missing")
-		}
-		if cfg.Notifier.Github.Repository.Name == "" {
-			return errors.New("repository name is missing")
-		}
+	if cfg.Notifier.Github.Repository.Owner == "" {
+		return errors.New("repository owner is missing")
 	}
-	notifier := cfg.GetNotifierType()
-	if notifier == "" {
-		return errors.New("notifier is missing")
+	if cfg.Notifier.Github.Repository.Name == "" {
+		return errors.New("repository name is missing")
 	}
 	return nil
-}
-
-func (cfg *Config) isDefinedGithub() bool {
-	// not empty
-	return cfg.Notifier.Github != (GithubNotifier{})
-}
-
-// GetNotifierType return notifier type described in Config
-func (cfg *Config) GetNotifierType() string {
-	if cfg.isDefinedGithub() {
-		return "github"
-	}
-	return ""
 }
 
 // Find returns config path


### PR DESCRIPTION
Close #55 

* -owner
* -repo
* -pr
* -sha
* -build-url

mercari/tfnotify gets these parameters from only environment variables, so we don't use mercari/tfnotify on the platform which mercari/tfnotify doesn't support.
On the other hand, tfcmt supports to specify these parameters by command-line options, so we can use tfcmt anywhere.

ex.

```
$ tfcmt -owner suzuki-shunsuke -repo tfcmt -pr 3 -- terraform plan
```