### PR TITLE
feat: support to hide old comments

### DIFF
--- a/COMPARED_WITH_TFNOTIFY.md
+++ b/COMPARED_WITH_TFNOTIFY.md
@@ -11,6 +11,7 @@ tfcmt isn't compatible with tfnotify.
   * [Remove --message and --destroy-warning-message option and template variable .Message](#breaking-change-remove---message-and---destroy-warning-message-option-and-template-variable-message)
   * [Remove --title and --destroy-warning-title options and template variable .Title](#breaking-change-remove---title-and---destroy-warning-title-options-and-template-variable-title)
   * [Don't remove duplicate comments](#breaking-change-dont-remove-duplicate-comments)
+  * [Hide old comments by default](#breaking-change-hide-old-comments-by-default)
   * [Change the behavior of deletion warning](#breaking-change-change-the-behavior-of-deletion-warning)
   * [Update labels by default](#breaking-change-update-pull-request-labels-by-default)
 * Features
@@ -121,6 +122,35 @@ tfnotify removes duplicate comments, but this feature isn't documented and confu
 The link to the comment would be broken when the comment would be removed.
 
 So this feature is removed from tfcmt.
+
+## Breaking Change: Hide old comments by default
+
+[#60](https://github.com/suzuki-shunsuke/tfcmt/pull/14)
+
+Instead of removing duplicate comments, tfcmt hides old comments of `terraform plan` by default.
+Comments of `terraform apply` aren't hidden.
+
+When tfcmt posts a comment, tfcmt injects a HTML comment `\n<!-- tfcmt:plan{{if .Vars.target}}:{{.Vars.target}}{{end}} -->` to the suffix.
+And before posting the comment, tfcmt gets a list of pull request comments and selects comments which will be hidden.
+
+Comments which match all of the following conditions are hidden.
+
+* comment author is same as tfcmt's authenticated user. When it failed to get the authenticated user login, this condition is ignored
+* tfcmt's authenticated user has a permission to hide the comment
+* comment includes `<!-- tfcmt:plan{{if .Vars.target}}:{{.Vars.target}}{{end}} -->`
+
+After it succeeds to post a comment, tfcmt hides them.
+If it failed to post a comment, comments aren't hidden.
+
+We can disable this feature by setting `terraform.plan.hide_old_comment.disable: true`.
+
+```yaml
+---
+terraform:
+  plan:
+    hide_old_comment:
+      disable: true
+```
 
 ## Breaking Change: Change the behavior of deletion warning
 

--- a/config/config.go
+++ b/config/config.go
@@ -67,7 +67,14 @@ type Plan struct {
 	WhenNoChanges       WhenNoChanges       `yaml:"when_no_changes,omitempty"`
 	WhenPlanError       WhenPlanError       `yaml:"when_plan_error,omitempty"`
 	WhenParseError      WhenParseError      `yaml:"when_parse_error,omitempty"`
+	HideOldComment      HideOldComment      `yaml:"hide_old_comment,omitempty"`
 	DisableLabel        bool                `yaml:"disable_label,omitempty"`
+}
+
+type HideOldComment struct {
+	//	Condition       string `yaml:"-"`
+	//	InjectedComment string `yaml:"-"`
+	Disable bool
 }
 
 // WhenAddOrUpdateOnly is a configuration to notify the plan result contains new or updated in place resources

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,8 @@ require (
 	github.com/mattn/go-colorable v0.1.8
 	github.com/mitchellh/copystructure v1.0.0 // indirect
 	github.com/sirupsen/logrus v1.7.0
+	github.com/shurcooL/githubv4 v0.0.0-20201206200315-234843c633fa
+	github.com/shurcooL/graphql v0.0.0-20200928012149-18c5c3165e3a // indirect
 	github.com/suzuki-shunsuke/go-ci-env v1.1.0
 	github.com/suzuki-shunsuke/go-findconfig v1.0.0
 	github.com/urfave/cli/v2 v2.3.0

--- a/go.sum
+++ b/go.sum
@@ -42,6 +42,10 @@ github.com/russross/blackfriday/v2 v2.0.1 h1:lPqVAte+HuHNfhJ/0LC98ESWRz8afy9tM/0
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/shopspring/decimal v1.2.0 h1:abSATXmQEYyShuxI4/vyW3tV1MrKAJzCZ/0zLUXYbsQ=
 github.com/shopspring/decimal v1.2.0/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=
+github.com/shurcooL/githubv4 v0.0.0-20201206200315-234843c633fa h1:jozR3igKlnYCj9IVHOVump59bp07oIRoLQ/CcjMYIUA=
+github.com/shurcooL/githubv4 v0.0.0-20201206200315-234843c633fa/go.mod h1:hAF0iLZy4td2EX+/8Tw+4nodhlMrwN3HupfaXj3zkGo=
+github.com/shurcooL/graphql v0.0.0-20200928012149-18c5c3165e3a h1:KikTa6HtAK8cS1qjvUvvq4QO21QnwC+EfvB+OAuZ/ZU=
+github.com/shurcooL/graphql v0.0.0-20200928012149-18c5c3165e3a/go.mod h1:AuYgA5Kyo4c7HfUmvRGs/6rGlMMV/6B1bVnB9JxJEEg=
 github.com/shurcooL/sanitized_anchor_name v1.0.0 h1:PdmoCO6wvbs+7yrJyMORt4/BmY5IYyJwS/kOiWx8mHo=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/sirupsen/logrus v1.7.0 h1:ShrD1U9pZB12TX0cVy0DtePoCH97K8EtX+mg7ZARUtM=

--- a/main.go
+++ b/main.go
@@ -146,6 +146,10 @@ func (t *tfcmt) getNotifier(ctx context.Context, ci CI) (notifier.Notifier, erro
 		}
 		labels = a
 	}
+	hideOldComment := github.HideOldComment{
+		Disable: t.config.Terraform.Plan.HideOldComment.Disable,
+	}
+
 	client, err := github.NewClient(ctx, github.Config{
 		Token:   t.config.Notifier.Github.Token,
 		BaseURL: t.config.Notifier.Github.BaseURL,
@@ -164,6 +168,7 @@ func (t *tfcmt) getNotifier(ctx context.Context, ci CI) (notifier.Notifier, erro
 		ResultLabels:           labels,
 		Vars:                   t.config.Vars,
 		Templates:              t.config.Templates,
+		HideOldComment:         hideOldComment,
 	})
 	if err != nil {
 		return nil, err

--- a/notifier/github/client.go
+++ b/notifier/github/client.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/google/go-github/v33/github"
+	"github.com/shurcooL/githubv4"
 	"github.com/suzuki-shunsuke/tfcmt/terraform"
 	"golang.org/x/oauth2"
 )
@@ -26,9 +27,11 @@ type Client struct {
 
 	common service
 
-	Comment *CommentService
-	Commits *CommitsService
-	Notify  *NotifyService
+	Comment  *CommentService
+	Commits  *CommitsService
+	Notify   *NotifyService
+	User     *UserService
+	v4Client *githubv4.Client
 
 	API API
 }
@@ -105,13 +108,15 @@ func NewClient(ctx context.Context, cfg Config) (*Client, error) {
 	}
 
 	c := &Client{
-		Config: cfg,
-		Client: client,
+		Config:   cfg,
+		Client:   client,
+		v4Client: githubv4.NewClient(tc),
 	}
 	c.common.client = c
 	c.Comment = (*CommentService)(&c.common)
 	c.Commits = (*CommitsService)(&c.common)
 	c.Notify = (*NotifyService)(&c.common)
+	c.User = (*UserService)(&c.common)
 
 	c.API = &GitHub{
 		Client: client,

--- a/notifier/github/client.go
+++ b/notifier/github/client.go
@@ -35,14 +35,13 @@ type Client struct {
 
 // Config is a configuration for GitHub client
 type Config struct {
-	Token        string
-	BaseURL      string
-	Owner        string
-	Repo         string
-	PR           PullRequest
-	CI           string
-	Parser       terraform.Parser
-	UseRawOutput bool
+	Token   string
+	BaseURL string
+	Owner   string
+	Repo    string
+	PR      PullRequest
+	CI      string
+	Parser  terraform.Parser
 	// Template is used for all Terraform command output
 	Template *terraform.Template
 	// DestroyWarningTemplate is used only for additional warning
@@ -50,9 +49,17 @@ type Config struct {
 	DestroyWarningTemplate *terraform.Template
 	ParseErrorTemplate     *terraform.Template
 	// ResultLabels is a set of labels to apply depending on the plan result
-	ResultLabels ResultLabels
-	Vars         map[string]string
-	Templates    map[string]string
+	ResultLabels   ResultLabels
+	Vars           map[string]string
+	Templates      map[string]string
+	HideOldComment HideOldComment
+	UseRawOutput   bool
+}
+
+type HideOldComment struct {
+	// Condition       string
+	// InjectedComment string
+	Disable bool
 }
 
 // PullRequest represents GitHub Pull Request metadata

--- a/notifier/github/comment.go
+++ b/notifier/github/comment.go
@@ -3,8 +3,10 @@ package github
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	"github.com/google/go-github/v33/github"
+	"github.com/shurcooL/githubv4"
 )
 
 // CommentService handles communication with the comment related
@@ -36,4 +38,126 @@ func (g *CommentService) Post(ctx context.Context, body string, opt PostOptions)
 		return err
 	}
 	return errors.New("github.comment.post: Number or Revision is required")
+}
+
+type ListOptions struct {
+	PRNumber int
+	Owner    string
+	Repo     string
+}
+
+type Comment struct {
+	ID     string
+	Body   string
+	Author struct {
+		Login string
+	}
+	CreatedAt string
+	// TODO remove
+	IsMinimized       bool
+	ViewerCanMinimize bool
+}
+
+func (g *CommentService) listIssueComment(ctx context.Context, opt ListOptions) ([]Comment, error) {
+	// https://github.com/shurcooL/githubv4#pagination
+	var q struct {
+		Repository struct {
+			Issue struct {
+				Comments struct {
+					Nodes    []Comment
+					PageInfo struct {
+						EndCursor   githubv4.String
+						HasNextPage bool
+					}
+				} `graphql:"comments(first: 100, after: $commentsCursor)"` // 100 per page.
+			} `graphql:"issue(number: $issueNumber)"`
+		} `graphql:"repository(owner: $repositoryOwner, name: $repositoryName)"`
+	}
+	variables := map[string]interface{}{
+		"repositoryOwner": githubv4.String(opt.Owner),
+		"repositoryName":  githubv4.String(opt.Repo),
+		"issueNumber":     githubv4.Int(opt.PRNumber),
+		"commentsCursor":  (*githubv4.String)(nil), // Null after argument to get first page.
+	}
+
+	var allComments []Comment
+	for {
+		if err := g.client.v4Client.Query(ctx, &q, variables); err != nil {
+			return nil, fmt.Errorf("list issue comments by GitHub API: %w", err)
+		}
+		allComments = append(allComments, q.Repository.Issue.Comments.Nodes...)
+		if !q.Repository.Issue.Comments.PageInfo.HasNextPage {
+			break
+		}
+		variables["commentsCursor"] = githubv4.NewString(q.Repository.Issue.Comments.PageInfo.EndCursor)
+	}
+	return allComments, nil
+}
+
+func (g *CommentService) listPRComment(ctx context.Context, opt ListOptions) ([]Comment, error) {
+	// https://github.com/shurcooL/githubv4#pagination
+	var q struct {
+		Repository struct {
+			PullRequest struct {
+				Comments struct {
+					Nodes    []Comment
+					PageInfo struct {
+						EndCursor   githubv4.String
+						HasNextPage bool
+					}
+				} `graphql:"comments(first: 100, after: $commentsCursor)"` // 100 per page.
+			} `graphql:"pullRequest(number: $issueNumber)"`
+		} `graphql:"repository(owner: $repositoryOwner, name: $repositoryName)"`
+	}
+	variables := map[string]interface{}{
+		"repositoryOwner": githubv4.String(opt.Owner),
+		"repositoryName":  githubv4.String(opt.Repo),
+		"issueNumber":     githubv4.Int(opt.PRNumber),
+		"commentsCursor":  (*githubv4.String)(nil), // Null after argument to get first page.
+	}
+
+	var allComments []Comment
+	for {
+		if err := g.client.v4Client.Query(ctx, &q, variables); err != nil {
+			return nil, fmt.Errorf("list issue comments by GitHub API: %w", err)
+		}
+		allComments = append(allComments, q.Repository.PullRequest.Comments.Nodes...)
+		if !q.Repository.PullRequest.Comments.PageInfo.HasNextPage {
+			break
+		}
+		variables["commentsCursor"] = githubv4.NewString(q.Repository.PullRequest.Comments.PageInfo.EndCursor)
+	}
+	return allComments, nil
+}
+
+func (g *CommentService) list(ctx context.Context, opt ListOptions) ([]Comment, error) {
+	cmts, prErr := g.listPRComment(ctx, opt)
+	if prErr == nil {
+		return cmts, nil
+	}
+	cmts, err := g.listIssueComment(ctx, opt)
+	if err == nil {
+		return cmts, nil
+	}
+	return nil, fmt.Errorf("get pull request or issue comments: %w, %v", prErr, err)
+}
+
+func (g *CommentService) hide(ctx context.Context, nodeID string) error {
+	var m struct {
+		MinimizeComment struct {
+			MinimizedComment struct {
+				MinimizedReason   githubv4.String
+				IsMinimized       githubv4.Boolean
+				ViewerCanMinimize githubv4.Boolean
+			}
+		} `graphql:"minimizeComment(input:$input)"`
+	}
+	input := githubv4.MinimizeCommentInput{
+		Classifier: githubv4.ReportedContentClassifiersOutdated,
+		SubjectID:  nodeID,
+	}
+	if err := g.client.v4Client.Mutate(ctx, &m, input, nil); err != nil {
+		return fmt.Errorf("hide an old comment: %w", err)
+	}
+	return nil
 }

--- a/notifier/github/user.go
+++ b/notifier/github/user.go
@@ -1,0 +1,13 @@
+package github
+
+import "context"
+
+type UserService service
+
+func (g *UserService) Get(ctx context.Context) (string, error) {
+	user, _, err := g.client.Users.Get(ctx, "")
+	if err != nil {
+		return "", err
+	}
+	return user.GetLogin(), nil
+}


### PR DESCRIPTION
Close #47 

## Breaking Changes

Old comments of `terraform plan` are hidden by default.

## Feature: support to hide old comments

tfcmt hides old comments of `terraform plan` by default.
Comments of `terraform apply` aren't hidden.

When tfcmt posts a comment, tfcmt injects a HTML comment `\n<!-- tfcmt:plan{{if .Vars.target}}:{{.Vars.target}}{{end}} -->` to the suffix.
And before posting the comment, tfcmt gets a list of pull request comments and selects comments which will be hidden.

Comments which match all of the following conditions are hidden.

* comment author is same as tfcmt's authenticated user. When it failed to get the authenticated user login, this condition is ignored
* tfcmt's authenticated user has a permission to hide the comment
* comment includes `<!-- tfcmt:plan{{if .Vars.target}}:{{.Vars.target}}{{end}} -->`

After it succeeds to post a comment, tfcmt hides them.
If it failed to post a comment, comments aren't hidden.

We can disable this feature by setting `terraform.plan.hide_old_comment.disable: true`.

```yaml
---
terraform:
  plan:
    hide_old_comment:
      disable: true
```