### PR TITLE
fix: remove the template variable Body

### DIFF
--- a/COMPARED_WITH_TFNOTIFY.md
+++ b/COMPARED_WITH_TFNOTIFY.md
@@ -8,6 +8,7 @@ tfcmt isn't compatible with tfnotify.
   * [Remove `fmt` command](#breaking-change-remove-fmt-command)
   * [Configuration file name is changed](#breaking-change-configuration-file-name-is-changed)
   * [Command usage is changed](#breaking-change-command-usage-is-changed)
+  * [template variable Body is removed](#breaking-change-template-variable-body-is-removed)
   * [Remove --message and --destroy-warning-message option and template variable .Message](#breaking-change-remove---message-and---destroy-warning-message-option-and-template-variable-message)
   * [Remove --title and --destroy-warning-title options and template variable .Title](#breaking-change-remove---title-and---destroy-warning-title-options-and-template-variable-title)
   * [Don't remove duplicate comments](#breaking-change-dont-remove-duplicate-comments)
@@ -101,6 +102,11 @@ tfcmt apply -- terraform apply
 
 By this change, tfcmt can handle the standard error output and exit code of the terraform command.
 
+## Breaking Change: template variable Body is removed
+
+template variable `Body` is removed. Replace `Body` to `CombinedOutput`.
+`CombinedOutput` includes both standard output and standard error output.
+
 ## Breaking Change: Remove --message and --destroy-warning-message option and template variable .Message
 
 [#40](https://github.com/suzuki-shunsuke/tfcmt/pull/40)
@@ -177,7 +183,7 @@ tfcmt posts only one comment whose template is `when_destroy.template`.
         {{end}}
         <details><summary>Details (Click me)</summary>
 
-        <pre><code>{{ .Body }}
+        <pre><code>{{ .CombinedOutput }}
         </pre></code></details>
 ```
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,6 @@ The example settings of GitHub and GitHub Enterprise are as follows. Incidentall
 Placeholder | Usage
 ---|---
 `{{ .Result }}` | Matched result by parsing like `Plan: 1 to add` or `No changes`
-`{{ .Body }}` | The entire of Terraform execution result
 `{{ .Link }}` | The link of the build page on CI
 `{{ .Vars }}` | The variables which are passed by `-var` option
 `{{ .Stdout }}` | The standard output of terraform command
@@ -108,7 +107,7 @@ terraform:
       {{end}}
       <details><summary>Details (Click me)</summary>
 
-      <pre><code>{{ .Body }}
+      <pre><code>{{ .CombinedOutput }}
       </pre></code></details>
   apply:
     template: |
@@ -119,7 +118,7 @@ terraform:
       {{end}}
       <details><summary>Details (Click me)</summary>
 
-      <pre><code>{{ .Body }}
+      <pre><code>{{ .CombinedOutput }}
       </pre></code></details>
 ```
 
@@ -139,7 +138,7 @@ terraform:
       {{end}}
       <details><summary>Details (Click me)</summary>
 
-      <pre><code>{{ .Body }}
+      <pre><code>{{ .CombinedOutput }}
       </pre></code></details>
     when_destroy:
       template: |
@@ -154,7 +153,7 @@ terraform:
         {{end}}
         <details><summary>Details (Click me)</summary>
 
-        <pre><code>{{ .Body }}
+        <pre><code>{{ .CombinedOutput }}
         </pre></code></details>
   # ...
 ```
@@ -175,7 +174,7 @@ terraform:
       {{end}}
       <details><summary>Details (Click me)</summary>
 
-      <pre><code>{{ .Body }}
+      <pre><code>{{ .CombinedOutput }}
       </pre></code></details>
     when_add_or_update_only:
       label: "add-or-update"
@@ -222,7 +221,7 @@ terraform:
       <details><summary>Details (Click me)</summary>
 
       ```
-      {{ .Body }}
+      {{ .CombinedOutput }}
       ```
   # ...
 ~~~
@@ -252,7 +251,7 @@ terraform:
       {{end}}
       <details><summary>Details (Click me)</summary>
 
-      <pre><code>{{ .Body }}
+      <pre><code>{{ .CombinedOutput }}
       </pre></code></details>
   apply:
     template: |
@@ -263,7 +262,7 @@ terraform:
       {{end}}
       <details><summary>Details (Click me)</summary>
 
-      <pre><code>{{ .Body }}
+      <pre><code>{{ .CombinedOutput }}
       </pre></code></details>
 ```
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -40,7 +40,7 @@ func TestLoadFile(t *testing.T) {
 						Template: "",
 					},
 					Plan: Plan{
-						Template:    "## Plan Result\n{{if .Result}}\n<pre><code>{{ .Result }}\n</pre></code>\n{{end}}\n<details><summary>Details (Click me)</summary>\n\n<pre><code>{{ .Body }}\n</pre></code></details>\n",
+						Template:    "## Plan Result\n{{if .Result}}\n<pre><code>{{ .Result }}\n</pre></code>\n{{end}}\n<details><summary>Details (Click me)</summary>\n\n<pre><code>{{ .CombinedOutput }}\n</pre></code></details>\n",
 						WhenDestroy: WhenDestroy{},
 					},
 					Apply: Apply{
@@ -70,7 +70,7 @@ func TestLoadFile(t *testing.T) {
 						Template: "",
 					},
 					Plan: Plan{
-						Template: "## Plan Result\n{{if .Result}}\n<pre><code>{{ .Result }}\n</pre></code>\n{{end}}\n<details><summary>Details (Click me)</summary>\n\n<pre><code>{{ .Body }}\n</pre></code></details>\n",
+						Template: "## Plan Result\n{{if .Result}}\n<pre><code>{{ .Result }}\n</pre></code>\n{{end}}\n<details><summary>Details (Click me)</summary>\n\n<pre><code>{{ .CombinedOutput }}\n</pre></code></details>\n",
 						WhenAddOrUpdateOnly: WhenAddOrUpdateOnly{
 							Label: "add-or-update",
 						},
@@ -112,7 +112,7 @@ func TestLoadFile(t *testing.T) {
 						Template: "",
 					},
 					Plan: Plan{
-						Template:    "## Plan Result\n{{if .Result}}\n<pre><code>{{ .Result }}\n</pre></code>\n{{end}}\n<details><summary>Details (Click me)</summary>\n\n<pre><code>{{ .Body }}\n</pre></code></details>\n",
+						Template:    "## Plan Result\n{{if .Result}}\n<pre><code>{{ .Result }}\n</pre></code>\n{{end}}\n<details><summary>Details (Click me)</summary>\n\n<pre><code>{{ .CombinedOutput }}\n</pre></code></details>\n",
 						WhenDestroy: WhenDestroy{},
 					},
 					Apply: Apply{

--- a/example-use-raw-output.tfcmt.yaml
+++ b/example-use-raw-output.tfcmt.yaml
@@ -16,5 +16,5 @@ terraform:
       {{end}}
       <details><summary>Details (Click me)</summary>
 
-      <pre><code>{{ .Body }}
+      <pre><code>{{ .CombinedOutput }}
       </pre></code></details>

--- a/example-with-destroy-and-result-labels.tfcmt.yaml
+++ b/example-with-destroy-and-result-labels.tfcmt.yaml
@@ -15,7 +15,7 @@ terraform:
       {{end}}
       <details><summary>Details (Click me)</summary>
 
-      <pre><code>{{ .Body }}
+      <pre><code>{{ .CombinedOutput }}
       </pre></code></details>
     when_add_or_update_only:
       label: "add-or-update"

--- a/example.tfcmt.yaml
+++ b/example.tfcmt.yaml
@@ -15,5 +15,5 @@ terraform:
       {{end}}
       <details><summary>Details (Click me)</summary>
 
-      <pre><code>{{ .Body }}
+      <pre><code>{{ .CombinedOutput }}
       </pre></code></details>

--- a/notifier/github/notify.go
+++ b/notifier/github/notify.go
@@ -22,8 +22,7 @@ func (g *NotifyService) Notify(ctx context.Context, param notifier.ParamExec) (i
 	var errMsgs []string
 	target := cfg.Vars["target"]
 
-	body := param.Stdout
-	result := parser.Parse(body)
+	result := parser.Parse(param.CombinedOutput)
 	result.ExitCode = param.ExitCode
 	if result.HasParseError {
 		template = g.client.Config.ParseErrorTemplate
@@ -48,7 +47,6 @@ func (g *NotifyService) Notify(ctx context.Context, param notifier.ParamExec) (i
 
 	template.SetValue(terraform.CommonTemplate{
 		Result:            result.Result,
-		Body:              body,
 		Link:              cfg.CI,
 		UseRawOutput:      cfg.UseRawOutput,
 		Vars:              cfg.Vars,

--- a/terraform/template.go
+++ b/terraform/template.go
@@ -19,7 +19,7 @@ const (
 {{template "result" .}}
 {{template "updated_resources" .}}
 <details><summary>Details (Click me)</summary>
-{{wrapCode .Body}}
+{{wrapCode .CombinedOutput}}
 </details>
 {{if .ErrorMessages}}
 ## :warning: Errors
@@ -36,7 +36,7 @@ const (
 {{template "result" .}}
 
 <details><summary>Details (Click me)</summary>
-{{wrapCode .Body}}
+{{wrapCode .CombinedOutput}}
 </details>
 {{if .ErrorMessages}}
 ## :warning: Errors
@@ -55,7 +55,7 @@ const (
 
 {{template "updated_resources" .}}
 <details><summary>Details (Click me)</summary>
-{{wrapCode .Body}}
+{{wrapCode .CombinedOutput}}
 </details>
 `
 
@@ -87,7 +87,6 @@ It failed to parse the result.
 // CommonTemplate represents template entities
 type CommonTemplate struct {
 	Result            string
-	Body              string
 	Link              string
 	UseRawOutput      bool
 	Vars              map[string]string
@@ -202,7 +201,6 @@ func generateOutput(kind, template string, data map[string]interface{}, useRawOu
 func (t *Template) Execute() (string, error) {
 	data := map[string]interface{}{
 		"Result":            t.Result,
-		"Body":              t.Body,
 		"Link":              t.Link,
 		"Vars":              t.Vars,
 		"Stdout":            t.Stdout,

--- a/terraform/template_test.go
+++ b/terraform/template_test.go
@@ -36,8 +36,8 @@ func TestPlanTemplateExecute(t *testing.T) {
 			name:     "case 1",
 			template: DefaultPlanTemplate,
 			value: CommonTemplate{
-				Result: "result",
-				Body:   "body",
+				Result:         "result",
+				CombinedOutput: "body",
 			},
 			resp: `
 ## Plan Result
@@ -59,8 +59,8 @@ body
 			name:     "case 2",
 			template: DefaultPlanTemplate,
 			value: CommonTemplate{
-				Result: "",
-				Body:   "body",
+				Result:         "",
+				CombinedOutput: "body",
 			},
 			resp: `
 ## Plan Result
@@ -82,8 +82,8 @@ body
 			name:     "case 3",
 			template: DefaultPlanTemplate,
 			value: CommonTemplate{
-				Result: "",
-				Body:   `This is a "body".`,
+				Result:         "",
+				CombinedOutput: `This is a "body".`,
 			},
 			resp: `
 ## Plan Result
@@ -105,9 +105,9 @@ This is a "body".
 			name:     "case 4",
 			template: DefaultPlanTemplate,
 			value: CommonTemplate{
-				Result:       "",
-				Body:         `This is a "body".`,
-				UseRawOutput: true,
+				Result:         "",
+				CombinedOutput: `This is a "body".`,
+				UseRawOutput:   true,
 			},
 			resp: `
 ## Plan Result
@@ -129,8 +129,8 @@ This is a "body".
 			name:     "case 5",
 			template: "",
 			value: CommonTemplate{
-				Result: "",
-				Body:   "body",
+				Result:         "",
+				CombinedOutput: "body",
 			},
 			resp: `
 ## Plan Result
@@ -150,10 +150,10 @@ body
 		},
 		{
 			name:     "case 6",
-			template: `{{ .Result }}-{{ .Body }}`,
+			template: `{{ .Result }}-{{ .CombinedOutput }}`,
 			value: CommonTemplate{
-				Result: "c",
-				Body:   "d",
+				Result:         "c",
+				CombinedOutput: "d",
 			},
 			resp: `c-d`,
 		},
@@ -312,10 +312,10 @@ This plan contains resource delete operation. Please check the plan result very 
 		},
 		{
 			name:     "case 5",
-			template: `{{ .Result }}-{{ .Body }}`,
+			template: `{{ .Result }}-{{ .CombinedOutput }}`,
 			value: CommonTemplate{
-				Result: "c",
-				Body:   "d",
+				Result:         "c",
+				CombinedOutput: "d",
 			},
 			resp: `c-d`,
 		},
@@ -372,8 +372,8 @@ func TestApplyTemplateExecute(t *testing.T) {
 			name:     "case 1",
 			template: DefaultApplyTemplate,
 			value: CommonTemplate{
-				Result: "result",
-				Body:   "body",
+				Result:         "result",
+				CombinedOutput: "body",
 			},
 			resp: `
 ## Apply Result
@@ -395,8 +395,8 @@ body
 			name:     "case 2",
 			template: DefaultApplyTemplate,
 			value: CommonTemplate{
-				Result: "",
-				Body:   "body",
+				Result:         "",
+				CombinedOutput: "body",
 			},
 			resp: `
 ## Apply Result
@@ -418,8 +418,8 @@ body
 			name:     "case 3",
 			template: "",
 			value: CommonTemplate{
-				Result: "",
-				Body:   "body",
+				Result:         "",
+				CombinedOutput: "body",
 			},
 			resp: `
 ## Apply Result
@@ -441,8 +441,8 @@ body
 			name:     "case 4",
 			template: "",
 			value: CommonTemplate{
-				Result: "",
-				Body:   `This is a "body".`,
+				Result:         "",
+				CombinedOutput: `This is a "body".`,
 			},
 			resp: `
 ## Apply Result
@@ -464,9 +464,9 @@ This is a "body".
 			name:     "case 5",
 			template: "",
 			value: CommonTemplate{
-				Result:       "",
-				Body:         `This is a "body".`,
-				UseRawOutput: true,
+				Result:         "",
+				CombinedOutput: `This is a "body".`,
+				UseRawOutput:   true,
 			},
 			resp: `
 ## Apply Result
@@ -486,10 +486,10 @@ This is a "body".
 		},
 		{
 			name:     "case 6",
-			template: `{{ .Result }}-{{ .Body }}`,
+			template: `{{ .Result }}-{{ .CombinedOutput }}`,
 			value: CommonTemplate{
-				Result: "c",
-				Body:   "d",
+				Result:         "c",
+				CombinedOutput: "d",
 			},
 			resp: `c-d`,
 		},


### PR DESCRIPTION
BREAKING CHNAGE: the template variable `Body` is removed.

Please replace `Body` into `CombinedOutput`.
`CombinedOutput` includes both the standard output and standard error output.

## Problem to solve

`tfcmt` parsed only the standard output and ignored standard error output, so it failed to parse the error result.