### PR TITLE
feat: support to complement options with any environment variables

### DIFF
--- a/COMPARED_WITH_TFNOTIFY.md
+++ b/COMPARED_WITH_TFNOTIFY.md
@@ -22,6 +22,7 @@ tfcmt isn't compatible with tfnotify.
   * [Make a configuration file optional](#feature-make-a-configuration-file-optional)
     * [Complement CI and GitHub Repository owner and name from environment variables](#feature-complement-ci-and-github-repository-owner-and-name-from-environment-variables)
     * [Get GitHub Token from the environment variable "GITHUB_TOKEN" by default](#feature-get-github-token-from-the-environment-variable-github_token-by-default)
+  * [Support Custom Environment Variable Definition](#feature-custom-environment-variable-definition)
   * [Support to configure label colors](#feature-support-to-configure-label-colors)
   * Support template functions [sprig](http://masterminds.github.io/sprig/)
   * [Support to pass variables by -var option](#feature-support-to-pass-variables-by--var-option)
@@ -306,6 +307,12 @@ notifier:
 ### Feature: Get GitHub Token from the environment variable "GITHUB_TOKEN" by default
 
 We can omit the configuration `notifier.github.token`.
+
+## Feature: Custom Environment Variable Definition
+
+We can complement the parameters like `pr` and `repo` on the other platform like Travis CI and Jenkins with Custom Environment Variable Definition.
+
+Please see [here](docs/ENVIRONMENT_VARIABLE.md#custom-environment-variable-definition).
 
 ## Feature: Support to configure label colors
 

--- a/README.md
+++ b/README.md
@@ -48,24 +48,6 @@ Please see [Command Usage](docs/USAGE.md).
 
 Please see [Configuration](docs/CONFIGURATION.md).
 
-## Supported CI
-
-Currently, supported CI are here:
-
-- CircleCI
-- Drone
-- AWS CodeBuild
-- GitHub Actions
-
-On the supported CI platform, the following parameters are complemented by the built-in environment variables.
-
-- `-owner`
-- `-repo`
-- `-pr`
-- `-sha`
-
-This feature is implemented by [go-ci-env](https://github.com/suzuki-shunsuke/go-ci-env).
-
 ## Release Notes
 
 Please see [GitHub Releases](https://github.com/suzuki-shunsuke/tfcmt/releases)

--- a/README.md
+++ b/README.md
@@ -15,6 +15,15 @@ we can know the result quickly without browsing the CI web page.
 
 https://github.com/suzuki-shunsuke/tfcmt/pull/70#issuecomment-797854184
 
+## Index
+
+- [Getting Started](examples/getting-started)
+- [Usage](docs/USAGE.md)
+- [Configuration](docs/CONFIGURATION.md)
+- [Environment Variable](docs/ENVIRONMENT_VARIABLE.md)
+- [Compared with tfnotify](COMPARED_WITH_TFNOTIFY.md)
+- [Release Notes](https://github.com/suzuki-shunsuke/tfcmt/releases)
+
 ## Forked version
 
 We forked [suzuki-shunsuke/tfnotify v1.3.3](https://github.com/suzuki-shunsuke/tfnotify/releases/tag/v1.3.3).

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -46,6 +46,7 @@ If the text includes <code>\`\`\`</code>, the text wraps with `<pre><code>`, oth
 
 ```yaml
 vars: {}
+ci: {}
 templates:
   plan_title: "## {{if eq .ExitCode 1}}:x: {{end}}Plan Result{{if .Vars.target}} ({{.Vars.target}}){{end}}"
   apply_title: "## :{{if eq .ExitCode 0}}white_check_mark{{else}}x{{end}}: Apply Result{{if .Vars.target}} ({{.Vars.target}}){{end}}"
@@ -155,3 +156,7 @@ terraform:
   plan:
     disable_label: true
 ```
+
+## Custom Environment Variable Definition
+
+Please see [Custom Environment Variable Definition](ENVIRONMENT_VARIABLE.md#custom-environment-variable-definition).

--- a/docs/ENVIRONMENT_VARIABLE.md
+++ b/docs/ENVIRONMENT_VARIABLE.md
@@ -1,0 +1,54 @@
+# Environment variable
+
+* GITHUB_TOKEN
+* [Native support of some CI platforms](#native-support-of-some-ci-platforms)
+* [Custom Environment Variable Definition](#custom-environment-variable-definition)
+
+## Native support of some CI platforms
+
+Currently, supported CI are here:
+
+- CircleCI
+- Drone
+- AWS CodeBuild
+- GitHub Actions
+
+On the supported CI platform, the following parameters are complemented by the built-in environment variables.
+
+- `-owner`
+- `-repo`
+- `-pr`
+- `-sha`
+- `-build-url`
+
+This feature is implemented by [go-ci-env](https://github.com/suzuki-shunsuke/go-ci-env).
+
+## Custom Environment Variable Definition
+
+You can complement the above parameters on the other platform like Travis CI and Jenkins with Custom Environment Variable Definition.
+
+tfcmt.yaml
+
+```yaml
+ci:
+  pr:
+  - type: envsubst
+    value: "${PR_NUMBER}"
+  sha:
+  - type: envsubst
+    value: "${SHA}"
+  link:
+  - type: envsubst
+    value: "${LINK}"
+  owner:
+  - type: envsubst
+    value: "${REPO_OWNER}"
+  repo:
+  - type: envsubst
+    value: "${REPO_NAME}"
+```
+
+The following types are supported.
+
+* `envsubst`: [drone/envsubst#EvalEnv](https://pkg.go.dev/github.com/drone/envsubst#EvalEnv)
+* `template`: Go's [text/template](https://golang.org/pkg/text/template/) with [sprig functions](http://masterminds.github.io/sprig/)

--- a/example-with-destroy-and-result-labels.tfcmt.yaml
+++ b/example-with-destroy-and-result-labels.tfcmt.yaml
@@ -1,6 +1,3 @@
-ci:
-  owner: "suzuki-shunsuke"
-  repo: "tfcmt"
 terraform:
   plan:
     template: |

--- a/example.tfcmt.yaml
+++ b/example.tfcmt.yaml
@@ -1,6 +1,10 @@
 ci:
-  owner: "suzuki-shunsuke"
-  repo: "tfcmt"
+  owner:
+  - type: envsubst
+    value: suzuki-shunsuke
+  repo:
+  - type: envsubst
+    value: tfcmt
 terraform:
   plan:
     template: |

--- a/examples/getting-started/README.md
+++ b/examples/getting-started/README.md
@@ -1,12 +1,7 @@
 # Getting Started
 
 In this getting started, we can understand tfcmt's primary feature.
-For the detail, please see other documents too.
-
-* [Configuration](../../docs/CONFIGURATION.md)
-* [Command Usage](../../docs/USAGE.md)
-* [Compared with tfnotify](../../COMPARED_WITH_TFNOTIFY.md)
-* [Release Notes](https://github.com/suzuki-shunsuke/tfcmt/releases)
+For the detail, please see [other documents](../../README.md#index) too.
 
 ## Requirements
 

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.13
 
 require (
 	github.com/Masterminds/sprig/v3 v3.2.2
+	github.com/drone/envsubst v1.0.2
 	github.com/google/go-github/v33 v33.0.0
 	github.com/google/uuid v1.1.3 // indirect
 	github.com/huandu/xstrings v1.3.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -11,9 +11,13 @@ github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:ma
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/drone/envsubst v1.0.2 h1:dpYLMAspQHW0a8dZpLRKe9jCNvIGZPhCPrycZzIHdqo=
+github.com/drone/envsubst v1.0.2/go.mod h1:bkZbnc/2vh1M12Ecn7EYScpI4YGYU0etwLJICOWi8Z0=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.2 h1:6nsPYzhq5kReh6QImI3k5qWzO4PEbvbIW2cwSfR/6xs=
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
+github.com/google/go-cmp v0.2.0 h1:+dTQ8DZQJz0Mb/HjFlkptS1FeQ4cWSnN941F8aEG4SQ=
+github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-github/v33 v33.0.0 h1:qAf9yP0qc54ufQxzwv+u9H0tiVOnPJxo0lI/JXqw3ZM=
 github.com/google/go-github/v33 v33.0.0/go.mod h1:GMdDnVZY/2TsWgp/lkYnpSAh6TrzhANBBwm6k6TTEXg=
 github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASuANWTrk=

--- a/pkg/cli/var.go
+++ b/pkg/cli/var.go
@@ -2,9 +2,6 @@ package cli
 
 import (
 	"errors"
-	"fmt"
-	"os"
-	"strconv"
 	"strings"
 
 	"github.com/suzuki-shunsuke/tfcmt/pkg/config"
@@ -37,16 +34,6 @@ func parseOpts(ctx *cli.Context, cfg *config.Config) error {
 
 	if pr := ctx.Int("pr"); pr != 0 {
 		cfg.CI.PRNumber = pr
-	}
-	if cfg.CI.PRNumber == 0 {
-		// support suzuki-shunsuke/ci-info
-		if prS := os.Getenv("CI_INFO_PR_NUMBER"); prS != "" {
-			a, err := strconv.Atoi(prS)
-			if err != nil {
-				return fmt.Errorf("parse CI_INFO_PR_NUMBER %s: %w", prS, err)
-			}
-			cfg.CI.PRNumber = a
-		}
 	}
 
 	if buildURL := ctx.String("build-url"); buildURL != "" {

--- a/pkg/config/complement.go
+++ b/pkg/config/complement.go
@@ -1,0 +1,101 @@
+package config
+
+import (
+	"errors"
+
+	"github.com/suzuki-shunsuke/tfcmt/pkg/domain"
+)
+
+type Complement struct {
+	PR    []domain.ComplementEntry
+	Owner []domain.ComplementEntry
+	Repo  []domain.ComplementEntry
+	SHA   []domain.ComplementEntry
+	Link  []domain.ComplementEntry
+}
+
+type rawComplement struct {
+	PR    []map[string]interface{}
+	Owner []map[string]interface{}
+	Repo  []map[string]interface{}
+	SHA   []map[string]interface{}
+	Link  []map[string]interface{}
+}
+
+func convComplementEntries(maps []map[string]interface{}) ([]domain.ComplementEntry, error) {
+	entries := make([]domain.ComplementEntry, len(maps))
+	for i, m := range maps {
+		entry, err := convComplementEntry(m)
+		if err != nil {
+			return nil, err
+		}
+		entries[i] = entry
+	}
+	return entries, nil
+}
+
+func convComplementEntry(m map[string]interface{}) (domain.ComplementEntry, error) {
+	t, ok := m["type"]
+	if !ok {
+		return nil, errors.New(`"type" is required`)
+	}
+	typ, ok := t.(string)
+	if !ok {
+		return nil, errors.New(`"type" must be string`)
+	}
+	switch typ {
+	case "envsubst":
+		entry := ComplementEnvsubstEntry{}
+		if err := newComplementEnvsubstEntry(m, &entry); err != nil {
+			return nil, err
+		}
+		return &entry, nil
+	case "template":
+		entry := ComplementTemplateEntry{}
+		if err := newComplementTemplateEntry(m, &entry); err != nil {
+			return nil, err
+		}
+		return &entry, nil
+	default:
+		return nil, errors.New(`unsupported type: ` + typ)
+	}
+}
+
+func (cpl *Complement) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var val rawComplement
+	if err := unmarshal(&val); err != nil {
+		return err
+	}
+
+	pr, err := convComplementEntries(val.PR)
+	if err != nil {
+		return err
+	}
+	cpl.PR = pr
+
+	owner, err := convComplementEntries(val.Owner)
+	if err != nil {
+		return err
+	}
+	cpl.Owner = owner
+
+	repo, err := convComplementEntries(val.Repo)
+	if err != nil {
+		return err
+	}
+	cpl.Repo = repo
+
+	sha, err := convComplementEntries(val.SHA)
+	if err != nil {
+		return err
+	}
+	cpl.SHA = sha
+
+	link, err := convComplementEntries(val.Link)
+	if err != nil {
+		return err
+	}
+	cpl.Link = link
+
+	return nil
+}

--- a/pkg/config/complement_envsubst.go
+++ b/pkg/config/complement_envsubst.go
@@ -1,0 +1,32 @@
+package config
+
+import (
+	"errors"
+
+	"github.com/drone/envsubst"
+)
+
+type ComplementEnvsubstEntry struct {
+	Value string
+}
+
+func (entry *ComplementEnvsubstEntry) Type() string {
+	return "envsubst"
+}
+
+func (entry *ComplementEnvsubstEntry) Entry() (string, error) {
+	return envsubst.EvalEnv(entry.Value)
+}
+
+func newComplementEnvsubstEntry(m map[string]interface{}, entry *ComplementEnvsubstEntry) error {
+	v, ok := m["value"]
+	if !ok {
+		return errors.New(`"value" is required`)
+	}
+	val, ok := v.(string)
+	if !ok {
+		return errors.New(`"value" must be string`)
+	}
+	entry.Value = val
+	return nil
+}

--- a/pkg/config/complement_template.go
+++ b/pkg/config/complement_template.go
@@ -1,0 +1,43 @@
+package config
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"text/template"
+
+	"github.com/Masterminds/sprig/v3"
+)
+
+type ComplementTemplateEntry struct {
+	Value string
+}
+
+func (entry *ComplementTemplateEntry) Type() string {
+	return "template"
+}
+
+func (entry *ComplementTemplateEntry) Entry() (string, error) {
+	tmpl, err := template.New("_").Funcs(sprig.TxtFuncMap()).Parse(entry.Value)
+	if err != nil {
+		return "", fmt.Errorf("parse a template %s: %w", entry.Value, err)
+	}
+	buf := &bytes.Buffer{}
+	if err := tmpl.Execute(buf, nil); err != nil {
+		return "", fmt.Errorf("render a template with params %s: %w", entry.Value, err)
+	}
+	return buf.String(), nil
+}
+
+func newComplementTemplateEntry(m map[string]interface{}, entry *ComplementTemplateEntry) error {
+	v, ok := m["value"]
+	if !ok {
+		return errors.New(`"value" is required`)
+	}
+	val, ok := v.(string)
+	if !ok {
+		return errors.New(`"value" must be string`)
+	}
+	entry.Value = val
+	return nil
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -12,23 +12,23 @@ import (
 
 // Config is for tfcmt config structure
 type Config struct {
-	CI          CI
+	CI          CI `yaml:"-"`
 	Terraform   Terraform
 	Vars        map[string]string `yaml:"-"`
 	Templates   map[string]string
 	Log         Log
-	GHEBaseURL  string `yaml:"ghe_base_url"`
-	GitHubToken string `yaml:"-"`
-	Complement  Complement
+	GHEBaseURL  string     `yaml:"ghe_base_url"`
+	GitHubToken string     `yaml:"-"`
+	Complement  Complement `yaml:"ci"`
 }
 
 type CI struct {
 	Name     string
 	Owner    string
 	Repo     string
-	SHA      string `yaml:"-"`
-	Link     string `yaml:"-"`
-	PRNumber int    `yaml:"-"`
+	SHA      string
+	Link     string
+	PRNumber int
 }
 
 type Log struct {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -19,6 +19,7 @@ type Config struct {
 	Log         Log
 	GHEBaseURL  string `yaml:"ghe_base_url"`
 	GitHubToken string `yaml:"-"`
+	Complement  Complement
 }
 
 type CI struct {
@@ -104,13 +105,18 @@ func (cfg *Config) LoadFile(path string) error {
 	return yaml.Unmarshal(raw, cfg)
 }
 
-// Validation validates config file
-func (cfg *Config) Validation() error {
+// Validate validates config file
+func (cfg *Config) Validate() error {
 	if cfg.CI.Owner == "" {
 		return errors.New("repository owner is missing")
 	}
+
 	if cfg.CI.Repo == "" {
 		return errors.New("repository name is missing")
+	}
+
+	if cfg.CI.SHA == "" && cfg.CI.PRNumber <= 0 {
+		return errors.New("pull request number or SHA (revision) is needed")
 	}
 	return nil
 }

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -36,13 +36,13 @@ type Command struct {
 // Run sends the notification with notifier
 func (ctrl *Controller) Run(ctx context.Context, command Command) error {
 	ci := ctrl.Config.CI
-	if err := platform.Complement(&ci); err != nil {
+	if err := platform.Complement(&ci, ctrl.Config.Complement); err != nil {
 		return err
 	}
 	ctrl.Config.CI = ci
 
-	if ctrl.Config.CI.SHA == "" && ctrl.Config.CI.PRNumber == 0 {
-		return errors.New("pull request number or SHA (revision) is needed")
+	if err := ctrl.Config.Validate(); err != nil {
+		return err
 	}
 
 	ntf, err := ctrl.getNotifier(ctx)

--- a/pkg/domain/complement.go
+++ b/pkg/domain/complement.go
@@ -1,0 +1,6 @@
+package domain
+
+type ComplementEntry interface {
+	Entry() (string, error)
+	Type() string
+}

--- a/pkg/platform/ci.go
+++ b/pkg/platform/ci.go
@@ -3,10 +3,37 @@ package platform
 import (
 	"fmt"
 	"os"
+	"strconv"
 
 	"github.com/suzuki-shunsuke/go-ci-env/cienv"
 	"github.com/suzuki-shunsuke/tfcmt/pkg/config"
 )
+
+func Complement(ci *config.CI, complement config.Complement) error {
+	if err := complementWithCIEnv(ci); err != nil {
+		return err
+	}
+
+	if err := complementCIInfo(ci); err != nil {
+		return err
+	}
+
+	return complementWithGeneric(ci, complement)
+}
+
+func complementCIInfo(ci *config.CI) error {
+	if ci.PRNumber <= 0 {
+		// support suzuki-shunsuke/ci-info
+		if prS := os.Getenv("CI_INFO_PR_NUMBER"); prS != "" {
+			a, err := strconv.Atoi(prS)
+			if err != nil {
+				return fmt.Errorf("parse CI_INFO_PR_NUMBER %s: %w", prS, err)
+			}
+			ci.PRNumber = a
+		}
+	}
+	return nil
+}
 
 func getLink(ciname string) string {
 	switch ciname {
@@ -30,7 +57,7 @@ func getLink(ciname string) string {
 	return ""
 }
 
-func Complement(ci *config.CI) error {
+func complementWithCIEnv(ci *config.CI) error {
 	if pt := cienv.Get(); pt != nil {
 		ci.Name = pt.CI()
 
@@ -46,7 +73,7 @@ func Complement(ci *config.CI) error {
 			ci.SHA = pt.SHA()
 		}
 
-		if ci.PRNumber == 0 {
+		if ci.PRNumber <= 0 {
 			n, err := pt.PRNumber()
 			if err != nil {
 				return err
@@ -58,5 +85,43 @@ func Complement(ci *config.CI) error {
 			ci.Link = getLink(ci.Name)
 		}
 	}
+	return nil
+}
+
+func complementWithGeneric(ci *config.CI, complement config.Complement) error {
+	gen := generic{
+		param: Param{
+			RepoOwner: complement.Owner,
+			RepoName:  complement.Repo,
+			SHA:       complement.SHA,
+			PRNumber:  complement.PR,
+			Link:      complement.Link,
+		},
+	}
+
+	if ci.Owner == "" {
+		ci.Owner = gen.RepoOwner()
+	}
+
+	if ci.Repo == "" {
+		ci.Repo = gen.RepoName()
+	}
+
+	if ci.SHA == "" {
+		ci.SHA = gen.SHA()
+	}
+
+	if ci.PRNumber <= 0 {
+		n, err := gen.PRNumber()
+		if err != nil {
+			return err
+		}
+		ci.PRNumber = n
+	}
+
+	if ci.Link == "" {
+		ci.Link = gen.Link()
+	}
+
 	return nil
 }

--- a/pkg/platform/generic.go
+++ b/pkg/platform/generic.go
@@ -1,0 +1,78 @@
+package platform
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/suzuki-shunsuke/tfcmt/pkg/domain"
+)
+
+type Param struct {
+	RepoOwner []domain.ComplementEntry
+	RepoName  []domain.ComplementEntry
+	SHA       []domain.ComplementEntry
+	PRNumber  []domain.ComplementEntry
+	Link      []domain.ComplementEntry
+}
+
+type generic struct {
+	param Param
+}
+
+func (gen *generic) render(entries []domain.ComplementEntry) (string, error) {
+	var e error
+	for _, entry := range entries {
+		a, err := entry.Entry()
+		if err != nil {
+			e = err
+			continue
+		}
+		if a != "" {
+			return a, nil
+		}
+	}
+	return "", e
+}
+
+func (gen *generic) returnString(entries []domain.ComplementEntry) string {
+	s, err := gen.render(entries)
+	if err != nil {
+		return ""
+	}
+	return s
+}
+
+func (gen *generic) RepoOwner() string {
+	return gen.returnString(gen.param.RepoOwner)
+}
+
+func (gen *generic) RepoName() string {
+	return gen.returnString(gen.param.RepoName)
+}
+
+func (gen *generic) SHA() string {
+	return gen.returnString(gen.param.SHA)
+}
+
+func (gen *generic) Link() string {
+	return gen.returnString(gen.param.Link)
+}
+
+func (gen *generic) IsPR() bool {
+	return gen.returnString(gen.param.PRNumber) != ""
+}
+
+func (gen *generic) PRNumber() (int, error) {
+	s, err := gen.render(gen.param.PRNumber)
+	if err != nil {
+		return 0, err
+	}
+	if s == "" {
+		return 0, nil
+	}
+	b, err := strconv.Atoi(s)
+	if err == nil {
+		return b, nil
+	}
+	return 0, fmt.Errorf("parse pull request number as int: %w", err)
+}


### PR DESCRIPTION
Close #57 

## BREAKING CHANGE

The configuration `ci` is changed.

AS IS

```yaml
ci:
  owner: suzuki-shunsuke
  repo: tfcmt
```

TO BE

```yaml
ci:
  owner:
  - type: envsubst
    value: suzuki-shunsuke
  repo:
  - type: envsubst
    value: tfcmt
```