### PR TITLE
feat: add template variables

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -17,6 +17,9 @@ The template is rendered with Go's [template](https://golang.org/pkg/html/templa
 Placeholder | Usage
 ---|---
 `{{ .Result }}` | Matched result by parsing like `Plan: 1 to add` or `No changes`
+`{{ .ChangedResult }}` |
+`{{ .ChangeOutsideTerraform }}` |
+`{{ .Warning }}` |
 `{{ .Link }}` | The link of the build page on CI
 `{{ .Vars }}` | The variables which are passed by `-var` option
 `{{ .Stdout }}` | The standard output of terraform command

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.16
 require (
 	github.com/Masterminds/sprig/v3 v3.2.2
 	github.com/drone/envsubst v1.0.3
+	github.com/google/go-cmp v0.5.6
 	github.com/google/go-github/v37 v37.0.0
 	github.com/google/uuid v1.1.3 // indirect
 	github.com/huandu/xstrings v1.3.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -92,6 +92,7 @@ golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae h1:/WDfKMnPU+m5M4xB+6x4kaepxRw6jWvR5iDRdvjHgy8=
 golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.4.0 h1:/wp5JvzpHIxhs/dumFmF7BXTf3Z+dd4uXta4kVyO508=

--- a/pkg/notifier/github/notify.go
+++ b/pkg/notifier/github/notify.go
@@ -47,7 +47,7 @@ func (g *NotifyService) Notify(ctx context.Context, param notifier.ParamExec) (i
 
 	template.SetValue(terraform.CommonTemplate{
 		Result:                 result.Result,
-		ChangedResult:          result.ChangeResult,
+		ChangedResult:          result.ChangedResult,
 		ChangeOutsideTerraform: result.OutsideTerraform,
 		Warnings:               result.Warnings,
 		Link:                   cfg.CI,

--- a/pkg/notifier/github/notify.go
+++ b/pkg/notifier/github/notify.go
@@ -49,7 +49,7 @@ func (g *NotifyService) Notify(ctx context.Context, param notifier.ParamExec) (i
 		Result:                 result.Result,
 		ChangedResult:          result.ChangedResult,
 		ChangeOutsideTerraform: result.OutsideTerraform,
-		Warnings:               result.Warnings,
+		Warning:                result.Warning,
 		Link:                   cfg.CI,
 		UseRawOutput:           cfg.UseRawOutput,
 		Vars:                   cfg.Vars,

--- a/pkg/notifier/github/notify.go
+++ b/pkg/notifier/github/notify.go
@@ -46,20 +46,23 @@ func (g *NotifyService) Notify(ctx context.Context, param notifier.ParamExec) (i
 	}
 
 	template.SetValue(terraform.CommonTemplate{
-		Result:            result.Result,
-		Link:              cfg.CI,
-		UseRawOutput:      cfg.UseRawOutput,
-		Vars:              cfg.Vars,
-		Templates:         cfg.Templates,
-		Stdout:            param.Stdout,
-		Stderr:            param.Stderr,
-		CombinedOutput:    param.CombinedOutput,
-		ExitCode:          param.ExitCode,
-		ErrorMessages:     errMsgs,
-		CreatedResources:  result.CreatedResources,
-		UpdatedResources:  result.UpdatedResources,
-		DeletedResources:  result.DeletedResources,
-		ReplacedResources: result.ReplacedResources,
+		Result:                 result.Result,
+		ChangedResult:          result.ChangeResult,
+		ChangeOutsideTerraform: result.OutsideTerraform,
+		Warnings:               result.Warnings,
+		Link:                   cfg.CI,
+		UseRawOutput:           cfg.UseRawOutput,
+		Vars:                   cfg.Vars,
+		Templates:              cfg.Templates,
+		Stdout:                 param.Stdout,
+		Stderr:                 param.Stderr,
+		CombinedOutput:         param.CombinedOutput,
+		ExitCode:               param.ExitCode,
+		ErrorMessages:          errMsgs,
+		CreatedResources:       result.CreatedResources,
+		UpdatedResources:       result.UpdatedResources,
+		DeletedResources:       result.DeletedResources,
+		ReplacedResources:      result.ReplacedResources,
 	})
 	body, err := template.Execute()
 	if err != nil {

--- a/pkg/terraform/parser.go
+++ b/pkg/terraform/parser.go
@@ -15,7 +15,7 @@ type Parser interface {
 type ParseResult struct {
 	Result             string
 	OutsideTerraform   string
-	ChangeResult       string
+	ChangedResult      string
 	Warnings           string
 	HasAddOrUpdateOnly bool
 	HasDestroy         bool
@@ -190,7 +190,7 @@ func (p *PlanParser) Parse(body string) ParseResult { //nolint:cyclop
 
 	return ParseResult{
 		Result:             result,
-		ChangeResult:       changeResult,
+		ChangedResult:      changeResult,
 		OutsideTerraform:   outsideTerraform,
 		Warnings:           warnings,
 		HasAddOrUpdateOnly: HasAddOrUpdateOnly,

--- a/pkg/terraform/parser.go
+++ b/pkg/terraform/parser.go
@@ -16,7 +16,7 @@ type ParseResult struct {
 	Result             string
 	OutsideTerraform   string
 	ChangedResult      string
-	Warnings           string
+	Warning            string
 	HasAddOrUpdateOnly bool
 	HasDestroy         bool
 	HasNoChanges       bool
@@ -192,7 +192,7 @@ func (p *PlanParser) Parse(body string) ParseResult { //nolint:cyclop
 		Result:             result,
 		ChangedResult:      changeResult,
 		OutsideTerraform:   outsideTerraform,
-		Warnings:           warnings,
+		Warning:            warnings,
 		HasAddOrUpdateOnly: HasAddOrUpdateOnly,
 		HasDestroy:         hasDestroy,
 		HasNoChanges:       hasNoChanges,

--- a/pkg/terraform/parser_test.go
+++ b/pkg/terraform/parser_test.go
@@ -338,7 +338,7 @@ func TestPlanParserParse(t *testing.T) {
 				HasPlanError:       false,
 				ExitCode:           0,
 				Error:              nil,
-				ChangeResult: `
+				ChangedResult: `
   + google_compute_global_address.my_another_project
       id:         <computed>
       address:    <computed>
@@ -407,7 +407,7 @@ Plan: 1 to add, 0 to change, 0 to destroy.`,
 				HasPlanError:       false,
 				ExitCode:           0,
 				Error:              nil,
-				ChangeResult: `
+				ChangedResult: `
   - google_project_iam_member.team_platform[2]
 
 
@@ -425,7 +425,7 @@ Plan: 0 to add, 0 to change, 1 to destroy.`,
 				HasPlanError:       false,
 				ExitCode:           0,
 				Error:              nil,
-				ChangeResult: `
+				ChangedResult: `
   + google_compute_global_address.my_another_project
       id:         <computed>
       address:    <computed>
@@ -450,7 +450,7 @@ Plan: 1 to add, 0 to change, 1 to destroy.`,
 				HasPlanError:       false,
 				ExitCode:           0,
 				Error:              nil,
-				ChangeResult: `
+				ChangedResult: `
   + google_compute_global_address.my_another_project
       id:         <computed>
       address:    <computed>

--- a/pkg/terraform/parser_test.go
+++ b/pkg/terraform/parser_test.go
@@ -2,8 +2,10 @@ package terraform
 
 import (
 	"errors"
-	"reflect"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 )
 
 const planSuccessResult = `
@@ -312,8 +314,8 @@ func TestDefaultParserParse(t *testing.T) {
 	}
 	for _, testCase := range testCases {
 		result := NewDefaultParser().Parse(testCase.body)
-		if !reflect.DeepEqual(result, testCase.result) {
-			t.Errorf("got %v but want %v", result, testCase.result)
+		if diff := cmp.Diff(result, testCase.result, cmpopts.IgnoreUnexported(ParseResult{}), cmpopts.IgnoreFields(ParseResult{}, "Error")); diff != "" {
+			t.Error(diff)
 		}
 	}
 }
@@ -336,6 +338,17 @@ func TestPlanParserParse(t *testing.T) {
 				HasPlanError:       false,
 				ExitCode:           0,
 				Error:              nil,
+				ChangeResult: `
+  + google_compute_global_address.my_another_project
+      id:         <computed>
+      address:    <computed>
+      ip_version: "IPV4"
+      name:       "my-another-project"
+      project:    "my-project"
+      self_link:  <computed>
+
+
+Plan: 1 to add, 0 to change, 0 to destroy.`,
 			},
 		},
 		{
@@ -394,6 +407,11 @@ func TestPlanParserParse(t *testing.T) {
 				HasPlanError:       false,
 				ExitCode:           0,
 				Error:              nil,
+				ChangeResult: `
+  - google_project_iam_member.team_platform[2]
+
+
+Plan: 0 to add, 0 to change, 1 to destroy.`,
 			},
 		},
 		{
@@ -407,6 +425,18 @@ func TestPlanParserParse(t *testing.T) {
 				HasPlanError:       false,
 				ExitCode:           0,
 				Error:              nil,
+				ChangeResult: `
+  + google_compute_global_address.my_another_project
+      id:         <computed>
+      address:    <computed>
+      ip_version: "IPV4"
+      name:       "my-another-project"
+      project:    "my-project"
+      self_link:  <computed>
+
+  - google_project_iam_member.team_platform[2]
+
+Plan: 1 to add, 0 to change, 1 to destroy.`,
 			},
 		},
 		{
@@ -420,6 +450,18 @@ func TestPlanParserParse(t *testing.T) {
 				HasPlanError:       false,
 				ExitCode:           0,
 				Error:              nil,
+				ChangeResult: `
+  + google_compute_global_address.my_another_project
+      id:         <computed>
+      address:    <computed>
+      ip_version: "IPV4"
+      name:       "my-another-project"
+      project:    "my-project"
+      self_link:  <computed>
+
+  ~ google_project_iam_member.team_platform[2]
+
+Plan: 1 to add, 1 to change, 0 to destroy.`,
 			},
 		},
 	}
@@ -428,8 +470,8 @@ func TestPlanParserParse(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 			result := NewPlanParser().Parse(testCase.body)
-			if !reflect.DeepEqual(result, testCase.result) {
-				t.Errorf("got %v but want %v", result, testCase.result)
+			if diff := cmp.Diff(result, testCase.result, cmpopts.IgnoreUnexported(ParseResult{}), cmpopts.IgnoreFields(ParseResult{}, "Error")); diff != "" {
+				t.Error(diff)
 			}
 		})
 	}
@@ -481,8 +523,8 @@ func TestApplyParserParse(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 			result := NewApplyParser().Parse(testCase.body)
-			if !reflect.DeepEqual(result, testCase.result) {
-				t.Errorf("got %v but want %v", result, testCase.result)
+			if diff := cmp.Diff(result, testCase.result, cmpopts.IgnoreUnexported(ParseResult{}), cmpopts.IgnoreFields(ParseResult{}, "Error")); diff != "" {
+				t.Error(diff)
 			}
 		})
 	}
@@ -521,8 +563,8 @@ func TestTrimLastNewline(t *testing.T) {
 	}
 	for _, testCase := range testCases {
 		actual := trimLastNewline(testCase.data)
-		if !reflect.DeepEqual(actual, testCase.expected) {
-			t.Errorf("got %v but want %v", actual, testCase.expected)
+		if diff := cmp.Diff(actual, testCase.expected); diff != "" {
+			t.Errorf(diff)
 		}
 	}
 }

--- a/pkg/terraform/template.go
+++ b/pkg/terraform/template.go
@@ -88,20 +88,23 @@ It failed to parse the result.
 
 // CommonTemplate represents template entities
 type CommonTemplate struct {
-	Result            string
-	Link              string
-	UseRawOutput      bool
-	Vars              map[string]string
-	Templates         map[string]string
-	Stdout            string
-	Stderr            string
-	CombinedOutput    string
-	ExitCode          int
-	ErrorMessages     []string
-	CreatedResources  []string
-	UpdatedResources  []string
-	DeletedResources  []string
-	ReplacedResources []string
+	Result                 string
+	ChangedResult          string
+	ChangeOutsideTerraform string
+	Warnings               string
+	Link                   string
+	UseRawOutput           bool
+	Vars                   map[string]string
+	Templates              map[string]string
+	Stdout                 string
+	Stderr                 string
+	CombinedOutput         string
+	ExitCode               int
+	ErrorMessages          []string
+	CreatedResources       []string
+	UpdatedResources       []string
+	DeletedResources       []string
+	ReplacedResources      []string
 }
 
 // Template is a default template for terraform commands
@@ -202,18 +205,21 @@ func generateOutput(kind, template string, data map[string]interface{}, useRawOu
 // Execute binds the execution result of terraform command into template
 func (t *Template) Execute() (string, error) {
 	data := map[string]interface{}{
-		"Result":            t.Result,
-		"Link":              t.Link,
-		"Vars":              t.Vars,
-		"Stdout":            t.Stdout,
-		"Stderr":            t.Stderr,
-		"CombinedOutput":    t.CombinedOutput,
-		"ExitCode":          t.ExitCode,
-		"ErrorMessages":     t.ErrorMessages,
-		"CreatedResources":  t.CreatedResources,
-		"UpdatedResources":  t.UpdatedResources,
-		"DeletedResources":  t.DeletedResources,
-		"ReplacedResources": t.ReplacedResources,
+		"Result":                 t.Result,
+		"ChangedResult":          t.ChangedResult,
+		"ChangeOutsideTerraform": t.ChangeOutsideTerraform,
+		"Warnings":               t.Warnings,
+		"Link":                   t.Link,
+		"Vars":                   t.Vars,
+		"Stdout":                 t.Stdout,
+		"Stderr":                 t.Stderr,
+		"CombinedOutput":         t.CombinedOutput,
+		"ExitCode":               t.ExitCode,
+		"ErrorMessages":          t.ErrorMessages,
+		"CreatedResources":       t.CreatedResources,
+		"UpdatedResources":       t.UpdatedResources,
+		"DeletedResources":       t.DeletedResources,
+		"ReplacedResources":      t.ReplacedResources,
 	}
 
 	templates := map[string]string{

--- a/pkg/terraform/template.go
+++ b/pkg/terraform/template.go
@@ -91,7 +91,7 @@ type CommonTemplate struct {
 	Result                 string
 	ChangedResult          string
 	ChangeOutsideTerraform string
-	Warnings               string
+	Warning                string
 	Link                   string
 	UseRawOutput           bool
 	Vars                   map[string]string
@@ -208,7 +208,7 @@ func (t *Template) Execute() (string, error) {
 		"Result":                 t.Result,
 		"ChangedResult":          t.ChangedResult,
 		"ChangeOutsideTerraform": t.ChangeOutsideTerraform,
-		"Warnings":               t.Warnings,
+		"Warning":                t.Warning,
 		"Link":                   t.Link,
 		"Vars":                   t.Vars,
 		"Stdout":                 t.Stdout,


### PR DESCRIPTION
Close #103 

The following variables are added.

* ChangedResult
* ChangeOutsideTerraform
* Warnings

## ChangedResult


## ChangeOutsideTerraform



## Warning

e.g.

```
Warning: "silenced": [DEPRECATED] Use the Downtime resource instead.

  with datadog_monitor.foo_success_rate,
  on foo.tf line 30, in resource "datadog_monitor" "foo_success_rate":
  30: resource "datadog_monitor" "foo_success_rate" {

(and one more similar warning elsewhere)

Warning: "thresholds": [DEPRECATED] Define `monitor_thresholds` list with one element instead.

  with datadog_monitor.foo_success_rate,
  on foo.tf line 30, in resource "datadog_monitor" "foo_success_rate":
  30: resource "datadog_monitor" "foo_success_rate" {

(and 7 more similar warnings elsewhere)
```

## Example

```yaml
    when_destroy:
      template: |
        {{template "plan_title" .}}

        {{if .Link}}[CI link]({{.Link}}){{end}}

        {{template "deletion_warning" .}}

        {{template "result" .}}

        {{template "updated_resources" .}}

        {{if .ChangedResult}}
        <details><summary>Change Result (Click me)</summary>
        {{wrapCode .ChangedResult}}
        </details>
        {{end}}

        {{if .ChangeOutsideTerraform}}
        <details><summary>:warning: Note: Objects have changed outside of Terraform</summary>
        {{wrapCode .ChangeOutsideTerraform}}
        </details>
        {{end}}

        {{if .Warnings}}
        ## :warning: Warnings :warning:
        {{wrapCode .Warnings}}
        {{end}}
```