### PR TITLE
feat: add embedded_var_names

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -12,14 +12,15 @@ import (
 
 // Config is for tfcmt config structure
 type Config struct {
-	CI          CI `yaml:"-"`
-	Terraform   Terraform
-	Vars        map[string]string `yaml:"-"`
-	Templates   map[string]string
-	Log         Log
-	GHEBaseURL  string     `yaml:"ghe_base_url"`
-	GitHubToken string     `yaml:"-"`
-	Complement  Complement `yaml:"ci"`
+	CI               CI `yaml:"-"`
+	Terraform        Terraform
+	Vars             map[string]string `yaml:"-"`
+	EmbeddedVarNames []string          `yaml:"embedded_var_names"`
+	Templates        map[string]string
+	Log              Log
+	GHEBaseURL       string     `yaml:"ghe_base_url"`
+	GitHubToken      string     `yaml:"-"`
+	Complement       Complement `yaml:"ci"`
 }
 
 type CI struct {

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -185,6 +185,7 @@ func (ctrl *Controller) getNotifier(ctx context.Context) (notifier.Notifier, err
 		ParseErrorTemplate: ctrl.ParseErrorTemplate,
 		ResultLabels:       labels,
 		Vars:               ctrl.Config.Vars,
+		EmbeddedVarNames:   ctrl.Config.EmbeddedVarNames,
 		Templates:          ctrl.Config.Templates,
 	})
 	if err != nil {

--- a/pkg/notifier/github/client.go
+++ b/pkg/notifier/github/client.go
@@ -49,10 +49,11 @@ type Config struct {
 	Template           *terraform.Template
 	ParseErrorTemplate *terraform.Template
 	// ResultLabels is a set of labels to apply depending on the plan result
-	ResultLabels ResultLabels
-	Vars         map[string]string
-	Templates    map[string]string
-	UseRawOutput bool
+	ResultLabels     ResultLabels
+	Vars             map[string]string
+	EmbeddedVarNames []string
+	Templates        map[string]string
+	UseRawOutput     bool
 }
 
 // PullRequest represents GitHub Pull Request metadata


### PR DESCRIPTION
Close #108

## BREAKING CHANGE: no variable becomes embedded in comment by default

tfcmt embedds the metadata into the comment to hide the comment by the metadata.
With tfcmt v1, all variables are embedded into the comment, but sometimes this behaviour is undesirable.
With tfcmt v2, only variables specified by `embedded_var_names` are embedded into the comment.

```yaml
embedded_var_names:
- name
```