### PR TITLE
fix: fix version

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -7,9 +7,6 @@ before:
 builds:
   - main: ./cmd/tfcmt
     binary: tfcmt
-    ldflags: 
-      - -s -w
-      - -X main.version={{.Version}}
     env:
       - CGO_ENABLED=0
 archives:


### PR DESCRIPTION
Follow up #140

```
$ tfcmt -v
tfcmt version 2.0.1 ()
```

The revision is empty.