### PR TITLE
Use HCL syntax

### DIFF
--- a/pkg/terraform/template.go
+++ b/pkg/terraform/template.go
@@ -146,7 +146,7 @@ func wrapCode(text string) interface{} {
 	if strings.Contains(text, "```") {
 		return `<pre><code>` + text + `</code></pre>`
 	}
-	return htmltemplate.HTML("\n```\n" + text + "\n```\n") //nolint:gosec
+	return htmltemplate.HTML("\n```hcl\n" + text + "\n```\n") //nolint:gosec
 }
 
 func generateOutput(kind, template string, data map[string]interface{}, useRawOutput bool) (string, error) {

--- a/pkg/terraform/template_test.go
+++ b/pkg/terraform/template_test.go
@@ -28,7 +28,7 @@ func TestPlanTemplateExecute(t *testing.T) {
 
 <details><summary>Details (Click me)</summary>
 
-` + "```" + `
+` + "```hcl" + `
 
 ` + "```" + `
 
@@ -76,7 +76,7 @@ body
 
 <details><summary>Details (Click me)</summary>
 
-` + "```" + `
+` + "```hcl" + `
 body
 ` + "```" + `
 
@@ -100,7 +100,7 @@ body
 
 <details><summary>Details (Click me)</summary>
 
-` + "```" + `
+` + "```hcl" + `
 This is a "body".
 ` + "```" + `
 
@@ -125,7 +125,7 @@ This is a "body".
 
 <details><summary>Details (Click me)</summary>
 
-` + "```" + `
+` + "```hcl" + `
 This is a "body".
 ` + "```" + `
 
@@ -149,7 +149,7 @@ This is a "body".
 
 <details><summary>Details (Click me)</summary>
 
-` + "```" + `
+` + "```hcl" + `
 body
 ` + "```" + `
 
@@ -207,7 +207,7 @@ func TestApplyTemplateExecute(t *testing.T) {
 
 <details><summary>Details (Click me)</summary>
 
-` + "```" + `
+` + "```hcl" + `
 
 ` + "```" + `
 
@@ -253,7 +253,7 @@ body
 
 <details><summary>Details (Click me)</summary>
 
-` + "```" + `
+` + "```hcl" + `
 body
 ` + "```" + `
 
@@ -276,7 +276,7 @@ body
 
 <details><summary>Details (Click me)</summary>
 
-` + "```" + `
+` + "```hcl" + `
 body
 ` + "```" + `
 
@@ -299,7 +299,7 @@ body
 
 <details><summary>Details (Click me)</summary>
 
-` + "```" + `
+` + "```hcl" + `
 This is a "body".
 ` + "```" + `
 
@@ -323,7 +323,7 @@ This is a "body".
 
 <details><summary>Details (Click me)</summary>
 
-` + "```" + `
+` + "```hcl" + `
 This is a "body".
 ` + "```" + `
 

--- a/pkg/terraform/template_test.go
+++ b/pkg/terraform/template_test.go
@@ -52,7 +52,7 @@ func TestPlanTemplateExecute(t *testing.T) {
 
 <details><summary>Details (Click me)</summary>
 
-` + "```" + `
+` + "```hcl" + `
 body
 ` + "```" + `
 
@@ -230,7 +230,7 @@ func TestApplyTemplateExecute(t *testing.T) {
 
 <details><summary>Details (Click me)</summary>
 
-` + "```" + `
+` + "```hcl" + `
 body
 ` + "```" + `
 


### PR DESCRIPTION
Using HCL syntax for terraform output is easier to read.

Ref: https://github.com/hashicorp/terraform-github-actions/issues/153