### PR TITLE
Provide an easy way to install tfcmt via GitHub Actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,20 @@ $ brew install suzuki-shunsuke/tfcmt/tfcmt
 
 You can install tfcmt with [aqua](https://aquaproj.github.io/) too.
 
+For GitHub Actions, [a helpful action](https://github.com/marketplace/actions/tfcmt) is available so that you can install it with a simple statement like below.
+
+```yaml
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: suzuki-shunsuke/tfcmt@v3
+        with:
+          version: v3.1.0
+      - run: tfcmt --version
+```
+
 ## What tfcmt does
 
 1. Parse the execution result of Terraform

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,31 @@
+name: tfcmt
+description: install tfcmt
+inputs:
+  version:
+    description: "The version of tfcmt to install"
+    default: latest
+    required: false
+runs:
+  using: "composite"
+  steps:
+    - shell: bash
+      working-directory: /tmp
+      run: |
+        set -e
+        VERSION="${{ inputs.version }}"
+        if [ "${VERSION}" = "latest" ]; then
+          DOWNLOAD_URL=$(curl -sS https://api.github.com/repos/suzuki-shunsuke/tfcmt/releases/latest|jq -r '.assets[].browser_download_url|select(match("linux.amd64."))')
+        else
+          DOWNLOAD_URL=$(curl -sS https://api.github.com/repos/suzuki-shunsuke/tfcmt/releases/tags/${VERSION}|jq -r '.assets[].browser_download_url|select(match("linux.amd64."))')
+        fi
+        cd /tmp
+        curl -sfLO ${DOWNLOAD_URL}
+        if [[ "${DOWNLOAD_URL}" =~ \.tar\.gz$ ]]; then
+          FILENAME=$(basename $DOWNLOAD_URL .tar.gz)
+          tar xzvf ${FILENAME}.tar.gz
+          sudo install tfcmt /usr/local/bin/tfcmt
+        elif [[ "${DOWNLOAD_URL}" =~ \.zip$ ]]; then
+          FILENAME=$(basename $DOWNLOAD_URL .zip)
+          unzip ${FILENAME}.zip
+          sudo install ${FILENAME} /usr/local/bin/tfcmt
+        fi


### PR DESCRIPTION
Thanks for your enthusiastic devotion into the development of such an excellent project!

I think it will be further more friendly to GitHub users with a feature like this, although I suppose that you, at least for work, use AWS CodeBuild as the platform to run Terraform on.