### PR TITLE
feat/out-option

### DIFF
--- a/pkg/cli/app.go
+++ b/pkg/cli/app.go
@@ -25,6 +25,7 @@ func New(flags *LDFlags) *cli.App {
 		&cli.StringFlag{Name: "sha", Usage: "commit SHA (revision)"},
 		&cli.StringFlag{Name: "build-url", Usage: "build url"},
 		&cli.StringFlag{Name: "log-level", Usage: "log level"},
+		&cli.StringFlag{Name: "out", Usage: "out put file name"},
 		&cli.IntFlag{Name: "pr", Usage: "pull request number"},
 		&cli.StringFlag{Name: "config", Usage: "config path"},
 		&cli.StringSliceFlag{Name: "var", Usage: "template variables. The format of value is '<name>:<value>'"},

--- a/pkg/cli/var.go
+++ b/pkg/cli/var.go
@@ -40,6 +40,10 @@ func parseOpts(ctx *cli.Context, cfg *config.Config) error {
 		cfg.CI.Link = buildURL
 	}
 
+	if output := ctx.String("out"); output != "" {
+		cfg.Out = output
+	}
+
 	vars := ctx.StringSlice("var")
 	vm := make(map[string]string, len(vars))
 	if err := parseVarOpts(vars, vm); err != nil {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -21,6 +21,7 @@ type Config struct {
 	GHEBaseURL       string     `yaml:"ghe_base_url"`
 	GitHubToken      string     `yaml:"-"`
 	Complement       Complement `yaml:"ci"`
+	Out              string
 }
 
 type CI struct {

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -180,6 +180,7 @@ func (ctrl *Controller) getNotifier(ctx context.Context) (notifier.Notifier, err
 		},
 		CI:                 ctrl.Config.CI.Link,
 		Parser:             ctrl.Parser,
+		Out:                ctrl.Config.Out,
 		UseRawOutput:       ctrl.Config.Terraform.UseRawOutput,
 		Template:           ctrl.Template,
 		ParseErrorTemplate: ctrl.ParseErrorTemplate,

--- a/pkg/notifier/github/client.go
+++ b/pkg/notifier/github/client.go
@@ -45,6 +45,7 @@ type Config struct {
 	PR      PullRequest
 	CI      string
 	Parser  terraform.Parser
+	Out     string
 	// Template is used for all Terraform command output
 	Template           *terraform.Template
 	ParseErrorTemplate *terraform.Template

--- a/pkg/notifier/github/notify.go
+++ b/pkg/notifier/github/notify.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"os"
+	"fmt"
 
 	"github.com/sirupsen/logrus"
 	"github.com/suzuki-shunsuke/github-comment-metadata/metadata"
@@ -93,6 +94,17 @@ func (g *NotifyService) Notify(ctx context.Context, param notifier.ParamExec) (i
 	}).Debug("embedded HTML comment")
 	// embed HTML tag to hide old comments
 	body += embeddedComment
+
+	output := g.client.Config.Out
+	if output != "" {
+		file, err := os.OpenFile(output, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0666)
+		if err != nil {
+			return result.ExitCode, err
+		}
+		defer file.Close()
+		fmt.Fprintln(file, body)
+		return result.ExitCode, nil
+	}
 
 	if err := g.client.Comment.Post(ctx, body, PostOptions{
 		Number:   cfg.PR.Number,


### PR DESCRIPTION
What
----
`tfcmt`はgithubのPRにterraformの結果を整形してコメントします。
これをコメントせずに任意のファイルに出力するようにします。

具体的には、`-out FILENAME` をtfcmtコマンドに追記することで
- 指定したファイルがない場合はカレントディレクトリに作成し、すでにある場合は一度空にして出力する
- PRにはコメントしないようになる

example
----
`tfcmt -out "output.log" -- terraform plan`を実行した場合(null_resouceのみ)
output.logに以下のように出力される。
```` output.log

## Plan Result




<pre><code>Plan: 1 to add, 0 to change, 0 to destroy.</code></pre>

* Create
  * null_resource.foo


<details><summary>Change Result (Click me)</summary>

```hcl

  # null_resource.foo will be created
  + resource "null_resource" "foo" {
      + id = (known after apply)
    }

Plan: 1 to add, 0 to change, 0 to destroy.
```

</details>




<!-- github-comment: {"Command":"plan","PRNumber":X,"Program":"tfcmt","SHA1":"","Vars":{}} -->

````

