### PR TITLE
Fix not removing stale labels if there are too many labels in the pull request

### DIFF
--- a/pkg/notifier/github/notify.go
+++ b/pkg/notifier/github/notify.go
@@ -217,7 +217,7 @@ func (g *NotifyService) removeResultLabels(ctx context.Context, label string) (s
 	cfg := g.client.Config
 	// A Pull Request can have 100 labels the maximum
 	labels, _, err := g.client.API.IssuesListLabels(ctx, cfg.PR.Number, &github.ListOptions{
-		PerPage: 100,
+		PerPage: 100, //nolint:gomnd
 	})
 	if err != nil {
 		return "", err

--- a/pkg/notifier/github/notify.go
+++ b/pkg/notifier/github/notify.go
@@ -216,10 +216,9 @@ func (g *NotifyService) updateLabels(ctx context.Context, result terraform.Parse
 func (g *NotifyService) removeResultLabels(ctx context.Context, label string) (string, error) {
 	cfg := g.client.Config
 	// A Pull Request can have 100 labels the maximum
-	listOption := &github.ListOptions{
+	labels, _, err := g.client.API.IssuesListLabels(ctx, cfg.PR.Number, &github.ListOptions{
 		PerPage: 100,
-	}
-	labels, _, err := g.client.API.IssuesListLabels(ctx, cfg.PR.Number, listOption)
+	})
 	if err != nil {
 		return "", err
 	}

--- a/pkg/notifier/github/notify.go
+++ b/pkg/notifier/github/notify.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"os"
 
+	"github.com/google/go-github/v39/github"
 	"github.com/sirupsen/logrus"
 	"github.com/suzuki-shunsuke/github-comment-metadata/metadata"
 	"github.com/suzuki-shunsuke/tfcmt/pkg/notifier"
@@ -214,7 +215,11 @@ func (g *NotifyService) updateLabels(ctx context.Context, result terraform.Parse
 
 func (g *NotifyService) removeResultLabels(ctx context.Context, label string) (string, error) {
 	cfg := g.client.Config
-	labels, _, err := g.client.API.IssuesListLabels(ctx, cfg.PR.Number, nil)
+	// A Pull Request can have 100 labels the maximum
+	listOption := &github.ListOptions{
+		PerPage: 100,
+	}
+	labels, _, err := g.client.API.IssuesListLabels(ctx, cfg.PR.Number, listOption)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
I encountered a problem that the label is not deleted from the pull request that has many labels (around 100).

Since I haven't met such a situation, I expected it's caused by a label append/delete operation.

I found `IssuesListLabels` is calling [ListLabelsByIssue](https://godoc.org/github.com/google/go-github/github#IssuesService.ListLabelsByIssue) function.

https://github.com/suzuki-shunsuke/tfcmt/blob/809b961216eec7a2b6628e61c8ede66929c2691c/pkg/notifier/github/github.go#L37-L40

It calls `GET /repos/{owner}/{repo}/issues/{issue_number}/labels` internally.
The doc is here: https://docs.github.com/en/rest/reference/issues#labels
`per_page` parameter is defaulted to 30, and it seems the root cause of this.

This endpoint have pagination parameter, but a issue / pull request can have 100 labels at maximum (tested on locally), so we don't need to implement pagination logic.