### PR TITLE
Support patching comment in `tfcmt plan`

### DIFF
--- a/pkg/cli/app.go
+++ b/pkg/cli/app.go
@@ -34,6 +34,12 @@ func New(flags *LDFlags) *cli.App {
 			Name:   "plan",
 			Usage:  "Run terraform plan and post a comment to GitHub commit or pull request",
 			Action: cmdPlan,
+			Flags: []cli.Flag{
+				&cli.BoolFlag{
+					Name:  "patch",
+					Usage: "update an existing comment instead of creating a new comment. If there is no existing comment, a new comment is created.",
+				},
+			},
 		},
 		{
 			Name:   "apply",

--- a/pkg/cli/var.go
+++ b/pkg/cli/var.go
@@ -36,6 +36,8 @@ func parseOpts(ctx *cli.Context, cfg *config.Config) error {
 		cfg.CI.PRNumber = pr
 	}
 
+	cfg.Patch = ctx.Bool("patch")
+
 	if buildURL := ctx.String("build-url"); buildURL != "" {
 		cfg.CI.Link = buildURL
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -21,6 +21,7 @@ type Config struct {
 	GHEBaseURL       string     `yaml:"ghe_base_url"`
 	GitHubToken      string     `yaml:"-"`
 	Complement       Complement `yaml:"ci"`
+	Patch            bool       `yaml:"-"`
 }
 
 type CI struct {

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -187,6 +187,7 @@ func (ctrl *Controller) getNotifier(ctx context.Context) (notifier.Notifier, err
 		Vars:               ctrl.Config.Vars,
 		EmbeddedVarNames:   ctrl.Config.EmbeddedVarNames,
 		Templates:          ctrl.Config.Templates,
+		Patch:              ctrl.Config.Patch,
 	})
 	if err != nil {
 		return nil, err

--- a/pkg/notifier/github/client.go
+++ b/pkg/notifier/github/client.go
@@ -54,6 +54,7 @@ type Config struct {
 	EmbeddedVarNames []string
 	Templates        map[string]string
 	UseRawOutput     bool
+	Patch            bool
 }
 
 // PullRequest represents GitHub Pull Request metadata

--- a/pkg/notifier/github/comment.go
+++ b/pkg/notifier/github/comment.go
@@ -40,6 +40,15 @@ func (g *CommentService) Post(ctx context.Context, body string, opt PostOptions)
 	return errors.New("github.comment.post: Number or Revision is required")
 }
 
+func (g *CommentService) Patch(ctx context.Context, body string, commentID int64) error {
+	_, _, err := g.client.API.IssuesEditComment(
+		ctx,
+		commentID,
+		&github.IssueComment{Body: &body},
+	)
+	return err
+}
+
 type ListOptions struct {
 	PRNumber int
 	Owner    string
@@ -47,7 +56,7 @@ type ListOptions struct {
 }
 
 type IssueComment struct {
-	ID     string
+	ID     int64
 	Body   string
 	Author struct {
 		Login string

--- a/pkg/notifier/github/comment.go
+++ b/pkg/notifier/github/comment.go
@@ -56,11 +56,8 @@ type ListOptions struct {
 }
 
 type IssueComment struct {
-	ID     int64
-	Body   string
-	Author struct {
-		Login string
-	}
+	DatabaseID int
+	Body       string
 }
 
 func (g *CommentService) listIssueComment(ctx context.Context, owner, repo string, number int) ([]*IssueComment, error) { //nolint:dupl

--- a/pkg/notifier/github/comment.go
+++ b/pkg/notifier/github/comment.go
@@ -52,10 +52,6 @@ type IssueComment struct {
 	Author struct {
 		Login string
 	}
-	CreatedAt string
-	// TODO remove
-	IsMinimized       bool
-	ViewerCanMinimize bool
 }
 
 func (g *CommentService) listIssueComment(ctx context.Context, owner, repo string, number int) ([]*IssueComment, error) { //nolint:dupl

--- a/pkg/notifier/github/comment.go
+++ b/pkg/notifier/github/comment.go
@@ -56,8 +56,9 @@ type ListOptions struct {
 }
 
 type IssueComment struct {
-	DatabaseID int
-	Body       string
+	DatabaseID  int
+	Body        string
+	IsMinimized bool
 }
 
 func (g *CommentService) listIssueComment(ctx context.Context, owner, repo string, number int) ([]*IssueComment, error) { //nolint:dupl

--- a/pkg/notifier/github/comment.go
+++ b/pkg/notifier/github/comment.go
@@ -3,8 +3,10 @@ package github
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	"github.com/google/go-github/v39/github"
+	"github.com/shurcooL/githubv4"
 )
 
 // CommentService handles communication with the comment related
@@ -42,4 +44,100 @@ type ListOptions struct {
 	PRNumber int
 	Owner    string
 	Repo     string
+}
+
+type IssueComment struct {
+	ID     string
+	Body   string
+	Author struct {
+		Login string
+	}
+	CreatedAt string
+	// TODO remove
+	IsMinimized       bool
+	ViewerCanMinimize bool
+}
+
+func (g *CommentService) listIssueComment(ctx context.Context, owner, repo string, number int) ([]*IssueComment, error) { //nolint:dupl
+	// https://github.com/shurcooL/githubv4#pagination
+	var q struct {
+		Repository struct {
+			Issue struct {
+				Comments struct {
+					Nodes    []*IssueComment
+					PageInfo struct {
+						EndCursor   githubv4.String
+						HasNextPage bool
+					}
+				} `graphql:"comments(first: 100, after: $commentsCursor)"` // 100 per page.
+			} `graphql:"issue(number: $issueNumber)"`
+		} `graphql:"repository(owner: $repositoryOwner, name: $repositoryName)"`
+	}
+	variables := map[string]interface{}{
+		"repositoryOwner": githubv4.String(owner),
+		"repositoryName":  githubv4.String(repo),
+		"issueNumber":     githubv4.Int(number),
+		"commentsCursor":  (*githubv4.String)(nil), // Null after argument to get first page.
+	}
+
+	var allComments []*IssueComment
+	for {
+		if err := g.client.v4Client.Query(ctx, &q, variables); err != nil {
+			return nil, fmt.Errorf("list issue comments by GitHub API: %w", err)
+		}
+		allComments = append(allComments, q.Repository.Issue.Comments.Nodes...)
+		if !q.Repository.Issue.Comments.PageInfo.HasNextPage {
+			break
+		}
+		variables["commentsCursor"] = githubv4.NewString(q.Repository.Issue.Comments.PageInfo.EndCursor)
+	}
+	return allComments, nil
+}
+
+func (g *CommentService) listPRComment(ctx context.Context, owner, repo string, number int) ([]*IssueComment, error) { //nolint:dupl
+	// https://github.com/shurcooL/githubv4#pagination
+	var q struct {
+		Repository struct {
+			PullRequest struct {
+				Comments struct {
+					Nodes    []*IssueComment
+					PageInfo struct {
+						EndCursor   githubv4.String
+						HasNextPage bool
+					}
+				} `graphql:"comments(first: 100, after: $commentsCursor)"` // 100 per page.
+			} `graphql:"pullRequest(number: $issueNumber)"`
+		} `graphql:"repository(owner: $repositoryOwner, name: $repositoryName)"`
+	}
+	variables := map[string]interface{}{
+		"repositoryOwner": githubv4.String(owner),
+		"repositoryName":  githubv4.String(repo),
+		"issueNumber":     githubv4.Int(number),
+		"commentsCursor":  (*githubv4.String)(nil), // Null after argument to get first page.
+	}
+
+	var allComments []*IssueComment
+	for {
+		if err := g.client.v4Client.Query(ctx, &q, variables); err != nil {
+			return nil, fmt.Errorf("list issue comments by GitHub API: %w", err)
+		}
+		allComments = append(allComments, q.Repository.PullRequest.Comments.Nodes...)
+		if !q.Repository.PullRequest.Comments.PageInfo.HasNextPage {
+			break
+		}
+		variables["commentsCursor"] = githubv4.NewString(q.Repository.PullRequest.Comments.PageInfo.EndCursor)
+	}
+	return allComments, nil
+}
+
+func (g *CommentService) List(ctx context.Context, owner, repo string, number int) ([]*IssueComment, error) {
+	cmts, prErr := g.listPRComment(ctx, owner, repo, number)
+	if prErr == nil {
+		return cmts, nil
+	}
+	cmts, err := g.listIssueComment(ctx, owner, repo, number)
+	if err == nil {
+		return cmts, nil
+	}
+	return nil, fmt.Errorf("get pull request or issue comments: %w, %v", prErr, err)
 }

--- a/pkg/notifier/github/github.go
+++ b/pkg/notifier/github/github.go
@@ -9,6 +9,7 @@ import (
 // API is GitHub API interface
 type API interface {
 	IssuesCreateComment(ctx context.Context, number int, comment *github.IssueComment) (*github.IssueComment, *github.Response, error)
+	IssuesEditComment(ctx context.Context, commentID int64, comment *github.IssueComment) (*github.IssueComment, *github.Response, error)
 	IssuesListLabels(ctx context.Context, number int, opt *github.ListOptions) ([]*github.Label, *github.Response, error)
 	IssuesAddLabels(ctx context.Context, number int, labels []string) ([]*github.Label, *github.Response, error)
 	IssuesRemoveLabel(ctx context.Context, number int, label string) (*github.Response, error)
@@ -21,12 +22,17 @@ type API interface {
 // GitHub represents the attribute information necessary for requesting GitHub API
 type GitHub struct {
 	*github.Client
-	owner, repo string
+	owner string
+	repo  string
 }
 
 // IssuesCreateComment is a wrapper of https://godoc.org/github.com/google/go-github/github#IssuesService.CreateComment
 func (g *GitHub) IssuesCreateComment(ctx context.Context, number int, comment *github.IssueComment) (*github.IssueComment, *github.Response, error) {
 	return g.Client.Issues.CreateComment(ctx, g.owner, g.repo, number, comment)
+}
+
+func (g *GitHub) IssuesEditComment(ctx context.Context, commentID int64, comment *github.IssueComment) (*github.IssueComment, *github.Response, error) {
+	return g.Client.Issues.EditComment(ctx, g.owner, g.repo, commentID, comment)
 }
 
 // IssuesAddLabels is a wrapper of https://godoc.org/github.com/google/go-github/github#IssuesService.AddLabelsToIssue

--- a/pkg/notifier/github/notify.go
+++ b/pkg/notifier/github/notify.go
@@ -137,6 +137,10 @@ func (g *NotifyService) Notify(ctx context.Context, param notifier.ParamExec) (i
 				logE.Debug("comment isn't changed")
 				return result.ExitCode, nil
 			}
+			if comment.IsMinimized {
+				logE.Debug("comment is hidden")
+				continue
+			}
 			logE.Debug("patch")
 			if err := g.client.Comment.Patch(ctx, body, int64(comment.DatabaseID)); err != nil {
 				return result.ExitCode, err

--- a/pkg/notifier/github/notify.go
+++ b/pkg/notifier/github/notify.go
@@ -109,39 +109,13 @@ func (g *NotifyService) Notify(ctx context.Context, param notifier.ParamExec) (i
 			return result.ExitCode, nil
 		}
 		logE.WithField("size", len(comments)).Debug("list comments")
-		target := cfg.Vars["target"]
-		for i, comment := range comments {
-			logE := logE.WithFields(logrus.Fields{
-				"comment_database_id": comment.DatabaseID,
-				"comment_index":       i,
-			})
-			data := &Metadata{}
-			f, err := metadata.Extract(comment.Body, data)
-			if err != nil {
-				logE.WithError(err).Debug("extract metadata from comment")
-				continue
-			}
-			if !f {
-				logE.Debug("metadata isn't found")
-				continue
-			}
-			if data.Program != "tfcmt" {
-				logE.Debug("Program isn't tfcmt")
-				continue
-			}
-			if data.Target != target {
-				logE.Debug("target is different")
-				continue
-			}
+		comment := g.getPatchedComment(logE, comments, cfg.Vars["target"])
+		if comment != nil {
 			if comment.Body == body {
 				logE.Debug("comment isn't changed")
 				return result.ExitCode, nil
 			}
-			if comment.IsMinimized {
-				logE.Debug("comment is hidden")
-				continue
-			}
-			logE.Debug("patch")
+			logE.WithField("comment_id", comment.DatabaseID).Debug("patch a comment")
 			if err := g.client.Comment.Patch(ctx, body, int64(comment.DatabaseID)); err != nil {
 				return result.ExitCode, err
 			}
@@ -149,6 +123,7 @@ func (g *NotifyService) Notify(ctx context.Context, param notifier.ParamExec) (i
 		}
 	}
 
+	logE.Debug("create a comment")
 	if err := g.client.Comment.Post(ctx, body, PostOptions{
 		Number:   cfg.PR.Number,
 		Revision: cfg.PR.Revision,
@@ -156,6 +131,40 @@ func (g *NotifyService) Notify(ctx context.Context, param notifier.ParamExec) (i
 		return result.ExitCode, err
 	}
 	return result.ExitCode, nil
+}
+
+func (g *NotifyService) getPatchedComment(logE *logrus.Entry, comments []*IssueComment, target string) *IssueComment {
+	var cmt *IssueComment
+	for i, comment := range comments {
+		logE := logE.WithFields(logrus.Fields{
+			"comment_database_id": comment.DatabaseID,
+			"comment_index":       i,
+		})
+		data := &Metadata{}
+		f, err := metadata.Extract(comment.Body, data)
+		if err != nil {
+			logE.WithError(err).Debug("extract metadata from comment")
+			continue
+		}
+		if !f {
+			logE.Debug("metadata isn't found")
+			continue
+		}
+		if data.Program != "tfcmt" {
+			logE.Debug("Program isn't tfcmt")
+			continue
+		}
+		if data.Target != target {
+			logE.Debug("target is different")
+			continue
+		}
+		if comment.IsMinimized {
+			logE.Debug("comment is hidden")
+			continue
+		}
+		cmt = comment
+	}
+	return cmt
 }
 
 type Metadata struct {


### PR DESCRIPTION
#199

The option `-patch` is added to `tfcmt plan` command.

```console
tfcmt plan -patch -- terraform plan -no-color
```

⚠️ `tfcmt apply` doesn't support patching. We think the comment of `terraform apply` shouldn't be patched.

## Trouble shooting

If the comment isn't patched expectedly, please set `-log-level=debug`.

```console
$ tfcmt -log-level=debug plan -patch -- terraform plan -no-color
```

## ⚠️ Exclude `tfcmt plan`'s comment from `github-comment hide` target

If you hide comments with [github-comment hide](https://suzuki-shunsuke.github.io/github-comment/hide),
you have to update the condition to prevent the comment of `tfcmt plan` being hidden.

e.g.

```yaml
hide:
  default: |
    Comment.HasMeta && Comment.Meta.SHA1 != Commit.SHA1 && Comment.Meta.Program != "tfcmt"
```