### PR TITLE
feat: add the configuration option `plan_patch`

### DIFF
--- a/pkg/cli/var.go
+++ b/pkg/cli/var.go
@@ -36,7 +36,9 @@ func parseOpts(ctx *cli.Context, cfg *config.Config) error {
 		cfg.CI.PRNumber = pr
 	}
 
-	cfg.Patch = ctx.Bool("patch")
+	if ctx.IsSet("patch") {
+		cfg.PlanPatch = ctx.Bool("patch")
+	}
 
 	if buildURL := ctx.String("build-url"); buildURL != "" {
 		cfg.CI.Link = buildURL

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -21,7 +21,7 @@ type Config struct {
 	GHEBaseURL       string     `yaml:"ghe_base_url"`
 	GitHubToken      string     `yaml:"-"`
 	Complement       Complement `yaml:"ci"`
-	Patch            bool       `yaml:"-"`
+	PlanPatch        bool       `yaml:"plan_patch"`
 }
 
 type CI struct {

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -187,7 +187,7 @@ func (ctrl *Controller) getNotifier(ctx context.Context) (notifier.Notifier, err
 		Vars:               ctrl.Config.Vars,
 		EmbeddedVarNames:   ctrl.Config.EmbeddedVarNames,
 		Templates:          ctrl.Config.Templates,
-		Patch:              ctrl.Config.Patch,
+		Patch:              ctrl.Config.PlanPatch,
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
https://github.com/suzuki-shunsuke/tfcmt/issues/199 Follow up #245

Support configuring tfcmt plan's patch in configuration file

```yaml
plan_patch: true
```

The command line option `-patch` takes precedence over configuration file option `plan_patch`.

If you want to disable patching although `plan_patch` is true, please set `-patch=false`.

```console
$ tfcmt plan -patch=false -- terraform plan -no-color
```