### PR TITLE
fix: set os.Stdin when terraform command is run

### DIFF
--- a/pkg/controller/apply.go
+++ b/pkg/controller/apply.go
@@ -34,6 +34,7 @@ func (ctrl *Controller) Apply(ctx context.Context, command Command) error {
 	}
 
 	cmd := exec.CommandContext(ctx, command.Cmd, command.Args...) //nolint:gosec
+	cmd.Stdin = os.Stdin
 	stdout := &bytes.Buffer{}
 	stderr := &bytes.Buffer{}
 	combinedOutput := &bytes.Buffer{}

--- a/pkg/controller/plan.go
+++ b/pkg/controller/plan.go
@@ -34,6 +34,7 @@ func (ctrl *Controller) Plan(ctx context.Context, command Command) error {
 	}
 
 	cmd := exec.CommandContext(ctx, command.Cmd, command.Args...) //nolint:gosec
+	cmd.Stdin = os.Stdin
 	stdout := &bytes.Buffer{}
 	stderr := &bytes.Buffer{}
 	combinedOutput := &bytes.Buffer{}


### PR DESCRIPTION
This change allows you to run `terraform apply` without `-auto-approve` option.

## AS IS

```console
tfcmt apply -- terraform apply -no-color
null_resource.foo: Refreshing state... [id=8966706083595703589]

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # null_resource.bar will be created
  + resource "null_resource" "bar" {
      + id = (known after apply)
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: 
Error: error asking for approval: EOF
```

```
Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: 
Error: error asking for approval: EOF
```

## TO BE

```console
tfcmt apply -- terraform apply -no-color
null_resource.foo: Refreshing state... [id=8966706083595703589]

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # null_resource.bar will be created
  + resource "null_resource" "bar" {
      + id = (known after apply)
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

null_resource.bar: Creating...
null_resource.bar: Creation complete after 0s [id=7780302426904623778]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
```