### PR TITLE
feat: support PR comments for push events

### DIFF
--- a/pkg/notifier/github/apply.go
+++ b/pkg/notifier/github/apply.go
@@ -53,7 +53,7 @@ func (g *NotifyService) Apply(ctx context.Context, param *notifier.ParamExec) (i
 		return result.ExitCode, err
 	}
 	if cfg.PR.Number == 0 {
-		if prNumber, err := g.client.Commits.MergedPRNumber(ctx, cfg.PR.Revision); err == nil {
+		if prNumber, err := g.client.Commits.PRNumber(ctx, cfg.PR.Revision, PullRequestStateClosed); err == nil {
 			cfg.PR.Number = prNumber
 		}
 	}

--- a/pkg/notifier/github/commits.go
+++ b/pkg/notifier/github/commits.go
@@ -9,13 +9,21 @@ import (
 // methods of GitHub API
 type CommitsService service
 
-func (g *CommitsService) MergedPRNumber(ctx context.Context, sha string) (int, error) {
+type PullRequestState string
+
+const (
+	PullRequestStateOpen   = "open"
+	PullRequestStateClosed = "closed"
+	PullRequestStateAll    = "all"
+)
+
+func (g *CommitsService) PRNumber(ctx context.Context, sha string, state PullRequestState) (int, error) {
 	prs, _, err := g.client.API.PullRequestsListPullRequestsWithCommit(ctx, sha, nil)
 	if err != nil {
 		return 0, err
 	}
 	for _, pr := range prs {
-		if pr.GetState() != "closed" {
+		if pr.GetState() != string(state) {
 			continue
 		}
 		return pr.GetNumber(), nil

--- a/pkg/notifier/github/commits.go
+++ b/pkg/notifier/github/commits.go
@@ -3,6 +3,8 @@ package github
 import (
 	"context"
 	"errors"
+
+	"github.com/google/go-github/v43/github"
 )
 
 // CommitsService handles communication with the commits related
@@ -18,15 +20,15 @@ const (
 )
 
 func (g *CommitsService) PRNumber(ctx context.Context, sha string, state PullRequestState) (int, error) {
-	prs, _, err := g.client.API.PullRequestsListPullRequestsWithCommit(ctx, sha, nil)
+	prs, _, err := g.client.API.PullRequestsListPullRequestsWithCommit(ctx, sha, &github.PullRequestListOptions{
+		State: string(state),
+		Sort:  "updated",
+	})
 	if err != nil {
 		return 0, err
 	}
-	for _, pr := range prs {
-		if pr.GetState() != string(state) {
-			continue
-		}
-		return pr.GetNumber(), nil
+	if len(prs) == 0 {
+		return 0, errors.New("associated pull request isn't found")
 	}
-	return 0, errors.New("associated pull request isn't found")
+	return prs[0].GetNumber(), nil
 }

--- a/pkg/notifier/github/commits_test.go
+++ b/pkg/notifier/github/commits_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 )
 
-func TestMergedPRNumber(t *testing.T) {
+func TestPRNumber(t *testing.T) {
 	t.Parallel()
 	testCases := []struct {
 		prNumber int
@@ -27,7 +27,7 @@ func TestMergedPRNumber(t *testing.T) {
 		}
 		api := newFakeAPI()
 		client.API = &api
-		prNumber, err := client.Commits.MergedPRNumber(context.Background(), testCase.revision)
+		prNumber, err := client.Commits.PRNumber(context.Background(), testCase.revision, PullRequestStateClosed)
 		if (err == nil) != testCase.ok {
 			t.Errorf("got error %q", err)
 		}

--- a/pkg/notifier/github/commits_test.go
+++ b/pkg/notifier/github/commits_test.go
@@ -13,7 +13,7 @@ func TestPRNumber(t *testing.T) {
 		revision string
 	}{
 		{
-			prNumber: 2,
+			prNumber: 1,
 			ok:       true,
 			revision: "xxx",
 		},
@@ -27,12 +27,12 @@ func TestPRNumber(t *testing.T) {
 		}
 		api := newFakeAPI()
 		client.API = &api
-		prNumber, err := client.Commits.PRNumber(context.Background(), testCase.revision, PullRequestStateClosed)
+		prNumber, err := client.Commits.PRNumber(context.Background(), testCase.revision, PullRequestStateOpen)
 		if (err == nil) != testCase.ok {
 			t.Errorf("got error %q", err)
 		}
 		if prNumber != testCase.prNumber {
-			t.Errorf("got %q but want %q", prNumber, testCase.prNumber)
+			t.Errorf("got %d but want %d", prNumber, testCase.prNumber)
 		}
 	}
 }

--- a/pkg/notifier/github/plan.go
+++ b/pkg/notifier/github/plan.go
@@ -56,6 +56,11 @@ func (g *NotifyService) Plan(ctx context.Context, param *notifier.ParamExec) (in
 	if err != nil {
 		return result.ExitCode, err
 	}
+	if cfg.PR.Number == 0 && cfg.PR.Revision != "" {
+		if prNumber, err := g.client.Commits.PRNumber(ctx, cfg.PR.Revision, PullRequestStateOpen); err == nil {
+			cfg.PR.Number = prNumber
+		}
+	}
 
 	logE := logrus.WithFields(logrus.Fields{
 		"program": "tfcmt",


### PR DESCRIPTION
Since GitHub no longer shows commit comments in the pull request timeline [^1], it needs to find a PR associated with a commit in a push event and then post a PR comment if found in order to show comments in the pull request timeline.

See https://github.com/suzuki-shunsuke/tfcmt/issues/387 for more details.

[^1]: github.blog/changelog/2022-08-04-commit-comments-no-longer-appear-in-the-pull-request-timeline