### PR TITLE
fix: github actions CI link domain

### DIFF
--- a/pkg/platform/ci.go
+++ b/pkg/platform/ci.go
@@ -49,7 +49,8 @@ func getLink(ciname string) string {
 		return os.Getenv("CODEBUILD_BUILD_URL")
 	case "github-actions":
 		return fmt.Sprintf(
-			"https://github.com/%s/actions/runs/%s",
+			"%s/%s/actions/runs/%s",
+			os.Getenv("GITHUB_SERVER_URL"),
 			os.Getenv("GITHUB_REPOSITORY"),
 			os.Getenv("GITHUB_RUN_ID"),
 		)


### PR DESCRIPTION
Thanks to provide awesome tool!

I noticed the link domain at comment is wrong when I use tfcmd with GitHub Enterprise Server.
GitHub Actions provides default environment variables, so I modified code to use it.
ref; https://docs.github.com/en/actions/learn-github-actions/environment-variables#default-environment-variables
