### PR TITLE
fix: get an associated pull request number before adding pull request labels

### DIFF
--- a/pkg/notifier/github/apply.go
+++ b/pkg/notifier/github/apply.go
@@ -15,6 +15,12 @@ func (g *NotifyService) Apply(ctx context.Context, param *notifier.ParamExec) (i
 	template := g.client.Config.Template
 	var errMsgs []string
 
+	if cfg.PR.Number == 0 {
+		if prNumber, err := g.client.Commits.PRNumber(ctx, cfg.PR.Revision, PullRequestStateClosed); err == nil {
+			cfg.PR.Number = prNumber
+		}
+	}
+
 	result := parser.Parse(param.CombinedOutput)
 	result.ExitCode = param.ExitCode
 	if result.HasParseError {
@@ -51,11 +57,6 @@ func (g *NotifyService) Apply(ctx context.Context, param *notifier.ParamExec) (i
 	body, err := template.Execute()
 	if err != nil {
 		return result.ExitCode, err
-	}
-	if cfg.PR.Number == 0 {
-		if prNumber, err := g.client.Commits.PRNumber(ctx, cfg.PR.Revision, PullRequestStateClosed); err == nil {
-			cfg.PR.Number = prNumber
-		}
 	}
 
 	logE := logrus.WithFields(logrus.Fields{

--- a/pkg/notifier/github/plan.go
+++ b/pkg/notifier/github/plan.go
@@ -15,6 +15,12 @@ func (g *NotifyService) Plan(ctx context.Context, param *notifier.ParamExec) (in
 	template := g.client.Config.Template
 	var errMsgs []string
 
+	if cfg.PR.Number == 0 && cfg.PR.Revision != "" {
+		if prNumber, err := g.client.Commits.PRNumber(ctx, cfg.PR.Revision, PullRequestStateOpen); err == nil {
+			cfg.PR.Number = prNumber
+		}
+	}
+
 	result := parser.Parse(param.CombinedOutput)
 	result.ExitCode = param.ExitCode
 	if result.HasParseError {
@@ -55,11 +61,6 @@ func (g *NotifyService) Plan(ctx context.Context, param *notifier.ParamExec) (in
 	body, err := template.Execute()
 	if err != nil {
 		return result.ExitCode, err
-	}
-	if cfg.PR.Number == 0 && cfg.PR.Revision != "" {
-		if prNumber, err := g.client.Commits.PRNumber(ctx, cfg.PR.Revision, PullRequestStateOpen); err == nil {
-			cfg.PR.Number = prNumber
-		}
 	}
 
 	logE := logrus.WithFields(logrus.Fields{


### PR DESCRIPTION
## Problem to solve

https://github.com/suzuki-shunsuke/tfcmt/blob/fc4a6c08b78b0b240c6a1d340f8c9a23807101a1/pkg/notifier/github/plan.go#L31-L33

Labels aren't set, because PR.IsNumber() is false.

tfcmt should get an associated pull request before adding pull request labels.