### PR TITLE
chore: add tfmct-gitlab reference to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Fork of [mercari/tfnotify](https://github.com/mercari/tfnotify), enhancing tfnot
 * https://suzuki-shunsuke.github.io/tfcmt/
 * https://github.com/suzuki-shunsuke/tfcmt-docs
 
-> tfcmt only supports **Github** Version Control System. Although, there is a fork of tfcmt that supports Gitlab, [tfcmt-gitlab](https://github.com/hirosassa/tfcmt-gitlab)
+> tfcmt supports notifying to only GitHub. If you'd like to notify to GitLab, maybe [tfcmt-gitlab](https://github.com/hirosassa/tfcmt-gitlab), which is a fork of tfcmt for GitLab, is useful.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Fork of [mercari/tfnotify](https://github.com/mercari/tfnotify), enhancing tfnot
 * https://suzuki-shunsuke.github.io/tfcmt/
 * https://github.com/suzuki-shunsuke/tfcmt-docs
 
+> tfcmt only supports **Github** Version Control System. Although, there is a fork of tfcmt that supports Gitlab, [tfcmt-gitlab](https://github.com/hirosassa/tfcmt-gitlab)
+
 ## License
 
 ### License of original code


### PR DESCRIPTION
This PR aims to close https://github.com/suzuki-shunsuke/tfcmt/issues/98 with a mere reference to the GL counterpart.