### PR TITLE
fix(localfile): append the output to a file instead of overwriting

### DIFF
--- a/pkg/notifier/localfile/output.go
+++ b/pkg/notifier/localfile/output.go
@@ -8,16 +8,18 @@ import (
 
 type OutputService service
 
+const filePermission os.FileMode = 0o644
+
 // WriteToFile Write result to file
 func (f *OutputService) WriteToFile(ctx context.Context, body string, outputFile string) error {
-	file, err := os.Create(outputFile)
+	file, err := os.OpenFile(outputFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, filePermission)
 	if err != nil {
-		return fmt.Errorf("create a file to output the result to a file: %w", err)
+		return fmt.Errorf("open a file to output the result to a file: %w", err)
 	}
 
 	defer file.Close()
 
-	if _, err := file.WriteString(body); err != nil {
+	if _, err := file.WriteString(body + "\n"); err != nil {
 		return fmt.Errorf("write the result to a file: %w", err)
 	}
 	return nil


### PR DESCRIPTION
## AS IS

If the file already exist, the file content is overwritten.

## TO BE

If the file already exist, the file content is appended.
If you prefer the behavior of `AS IS`, please [make the file empty](https://www.tecmint.com/empty-delete-file-content-linux/).

e.g.

```console
: > plan.md
tfcmt --output plan.md plan -- terraform plan
```