### PR TITLE
feat: support skipping no changes

### DIFF
--- a/pkg/cli/app.go
+++ b/pkg/cli/app.go
@@ -72,6 +72,10 @@ func New(flags *LDFlags) *cli.App {
 					Name:  "patch",
 					Usage: "update an existing comment instead of creating a new comment. If there is no existing comment, a new comment is created.",
 				},
+				&cli.BoolFlag{
+					Name:  "skip-no-changes",
+					Usage: "If there is no change tfcmt updates a label but doesn't post a comment",
+				},
 			},
 		},
 		{

--- a/pkg/cli/var.go
+++ b/pkg/cli/var.go
@@ -62,6 +62,10 @@ func parseOpts(ctx *cli.Context, cfg *config.Config, envs []string) error {
 		cfg.Output = output
 	}
 
+	if ctx.IsSet("skip-no-changes") {
+		cfg.Terraform.Plan.WhenNoChanges.DisableComment = ctx.Bool("skip-no-changes")
+	}
+
 	vars := ctx.StringSlice("var")
 	vm := make(map[string]string, len(vars))
 	if err := parseVars(vars, envs, vm); err != nil {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -74,9 +74,10 @@ type WhenDestroy struct {
 
 // WhenNoChanges is a configuration to add a label when the plan result contains no change
 type WhenNoChanges struct {
-	Label        string
-	Color        string `yaml:"label_color"`
-	DisableLabel bool   `yaml:"disable_label"`
+	Label          string
+	Color          string `yaml:"label_color"`
+	DisableLabel   bool   `yaml:"disable_label"`
+	DisableComment bool   `yaml:"disable_comment"`
 }
 
 // WhenPlanError is a configuration to notify the plan result returns an error

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -169,6 +169,7 @@ func (ctrl *Controller) getNotifier(ctx context.Context) (notifier.Notifier, err
 		EmbeddedVarNames:   ctrl.Config.EmbeddedVarNames,
 		Templates:          ctrl.Config.Templates,
 		Patch:              ctrl.Config.PlanPatch,
+		SkipNoChanges:      ctrl.Config.Terraform.Plan.WhenNoChanges.DisableComment,
 	})
 	if err != nil {
 		return nil, err

--- a/pkg/notifier/github/client.go
+++ b/pkg/notifier/github/client.go
@@ -56,6 +56,7 @@ type Config struct {
 	Templates        map[string]string
 	UseRawOutput     bool
 	Patch            bool
+	SkipNoChanges    bool
 }
 
 // PullRequest represents GitHub Pull Request metadata

--- a/pkg/notifier/github/plan.go
+++ b/pkg/notifier/github/plan.go
@@ -105,6 +105,11 @@ func (g *NotifyService) Plan(ctx context.Context, param *notifier.ParamExec) (in
 		}
 	}
 
+	if result.HasNoChanges && cfg.SkipNoChanges {
+		logE.Debug("skip posting a comment because there is no change")
+		return result.ExitCode, nil
+	}
+
 	logE.Debug("create a comment")
 	if err := g.client.Comment.Post(ctx, body, &PostOptions{
 		Number:   cfg.PR.Number,

--- a/pkg/notifier/github/plan.go
+++ b/pkg/notifier/github/plan.go
@@ -105,7 +105,7 @@ func (g *NotifyService) Plan(ctx context.Context, param *notifier.ParamExec) (in
 		}
 	}
 
-	if result.HasNoChanges && cfg.SkipNoChanges {
+	if result.HasNoChanges && result.Warning == "" && len(errMsgs) == 0 && cfg.SkipNoChanges {
 		logE.Debug("skip posting a comment because there is no change")
 		return result.ExitCode, nil
 	}


### PR DESCRIPTION
- https://github.com/suzuki-shunsuke/tfcmt/discussions/773

--

- Add a command line option `-skip-no-changes` to the subcommand `plan`
- Add a field `disable_comment` to the configuration file

e.g.

```console
$ tfcmt plan -skip-no-changes -- terraform plan
```

```yaml
terraform:
  plan:
    when_no_changes:
      disable_comment: true
```