### PR TITLE
feat: add moved resources to changed resources

### DIFF
--- a/pkg/notifier/github/plan.go
+++ b/pkg/notifier/github/plan.go
@@ -57,6 +57,7 @@ func (g *NotifyService) Plan(ctx context.Context, param *notifier.ParamExec) (in
 		UpdatedResources:       result.UpdatedResources,
 		DeletedResources:       result.DeletedResources,
 		ReplacedResources:      result.ReplacedResources,
+		MovedResources:         result.MovedResources,
 	})
 	body, err := template.Execute()
 	if err != nil {

--- a/pkg/terraform/template.go
+++ b/pkg/terraform/template.go
@@ -89,6 +89,7 @@ type CommonTemplate struct {
 	UpdatedResources       []string
 	DeletedResources       []string
 	ReplacedResources      []string
+	MovedResources         []*MovedResource
 }
 
 // Template is a default template for terraform commands
@@ -203,6 +204,7 @@ func (t *Template) Execute() (string, error) {
 		"UpdatedResources":       t.UpdatedResources,
 		"DeletedResources":       t.DeletedResources,
 		"ReplacedResources":      t.ReplacedResources,
+		"MovedResources":         t.MovedResources,
 		"HasDestroy":             t.HasDestroy,
 	}
 
@@ -226,6 +228,10 @@ func (t *Template) Execute() (string, error) {
 * Replace
 {{- range .ReplacedResources}}
   * {{.}}
+{{- end}}{{end}}{{if .MovedResources}}
+* Move
+{{- range .MovedResources}}
+  * {{.Before}} => {{.After}}
 {{- end}}{{end}}`,
 		"deletion_warning": `{{if .HasDestroy}}
 ### :warning: Resource Deletion will happen :warning:


### PR DESCRIPTION
Parse the output of `terraform plan` and extract moved resources.

e.g.

```tf
  # null_resource.foo has moved to null_resource.bar
```

Add the template variable `MovedResources`, which is a list of moved resources.

e.g.

```yaml
MovedResources:
  - Before: null_resource.foo
    After: null_resource.bar
```

Add the list of moved resources to the built in template `updated_resources`.

## Example

```
* Move
  * null_resource.foo => null_resource.bar
```

### Plan Result

<pre><code>Plan: 0 to add, 0 to change, 0 to destroy.</code></pre>

* Move
  * null_resource.foo => null_resource.bar

<details><summary>Change Result (Click me)</summary>

```hcl

  # null_resource.foo has moved to null_resource.bar
    resource "null_resource" "bar" {
        id = "4394414639163400357"
    }

Plan: 0 to add, 0 to change, 0 to destroy.
```

</details>

<!-- github-comment: {"Command":"plan","JobID":"","JobName":"","PRNumber":0,"Program":"tfcmt","SHA1":"","Vars":{}} -->