### PR TITLE
refactor: stop returning the exit code

### DIFF
--- a/pkg/controller/apply.go
+++ b/pkg/controller/apply.go
@@ -46,7 +46,7 @@ func (ctrl *Controller) Apply(ctx context.Context, command Command) error {
 	setCancel(cmd)
 	_ = cmd.Run()
 
-	return apperr.NewExitError(ntf.Apply(ctx, &notifier.ParamExec{
+	return apperr.NewExitError(cmd.ProcessState.ExitCode(), ntf.Apply(ctx, &notifier.ParamExec{
 		Stdout:         stdout.String(),
 		Stderr:         stderr.String(),
 		CombinedOutput: combinedOutput.String(),

--- a/pkg/controller/plan.go
+++ b/pkg/controller/plan.go
@@ -47,7 +47,7 @@ func (ctrl *Controller) Plan(ctx context.Context, command Command) error {
 	setCancel(cmd)
 	_ = cmd.Run()
 
-	return apperr.NewExitError(ntf.Plan(ctx, &notifier.ParamExec{
+	return apperr.NewExitError(cmd.ProcessState.ExitCode(), ntf.Plan(ctx, &notifier.ParamExec{
 		Stdout:         stdout.String(),
 		Stderr:         stderr.String(),
 		CombinedOutput: combinedOutput.String(),

--- a/pkg/notifier/github/apply.go
+++ b/pkg/notifier/github/apply.go
@@ -9,7 +9,7 @@ import (
 )
 
 // Apply posts comment optimized for notifications
-func (g *NotifyService) Apply(ctx context.Context, param *notifier.ParamExec) (int, error) {
+func (g *NotifyService) Apply(ctx context.Context, param *notifier.ParamExec) error {
 	cfg := g.client.Config
 	parser := g.client.Config.Parser
 	template := g.client.Config.Template
@@ -27,10 +27,10 @@ func (g *NotifyService) Apply(ctx context.Context, param *notifier.ParamExec) (i
 		template = g.client.Config.ParseErrorTemplate
 	} else {
 		if result.Error != nil {
-			return result.ExitCode, result.Error
+			return result.Error
 		}
 		if result.Result == "" {
-			return result.ExitCode, result.Error
+			return result.Error
 		}
 	}
 
@@ -56,7 +56,7 @@ func (g *NotifyService) Apply(ctx context.Context, param *notifier.ParamExec) (i
 	})
 	body, err := template.Execute()
 	if err != nil {
-		return result.ExitCode, err
+		return err
 	}
 
 	logE := logrus.WithFields(logrus.Fields{
@@ -65,7 +65,7 @@ func (g *NotifyService) Apply(ctx context.Context, param *notifier.ParamExec) (i
 
 	embeddedComment, err := getEmbeddedComment(cfg, param.CIName, false)
 	if err != nil {
-		return result.ExitCode, err
+		return err
 	}
 	logE.WithFields(logrus.Fields{
 		"comment": embeddedComment,
@@ -78,7 +78,7 @@ func (g *NotifyService) Apply(ctx context.Context, param *notifier.ParamExec) (i
 		Number:   cfg.PR.Number,
 		Revision: cfg.PR.Revision,
 	}); err != nil {
-		return result.ExitCode, err
+		return err
 	}
-	return result.ExitCode, nil
+	return nil
 }

--- a/pkg/notifier/github/notify_test.go
+++ b/pkg/notifier/github/notify_test.go
@@ -14,7 +14,6 @@ func TestNotifyApply(t *testing.T) {
 		name      string
 		config    Config
 		ok        bool
-		exitCode  int
 		paramExec notifier.ParamExec
 	}{
 		{
@@ -36,8 +35,7 @@ func TestNotifyApply(t *testing.T) {
 				Stdout:   "Apply complete!",
 				ExitCode: 0,
 			},
-			ok:       true,
-			exitCode: 0,
+			ok: true,
 		},
 		{
 			name: "case 9",
@@ -59,8 +57,7 @@ func TestNotifyApply(t *testing.T) {
 				Stdout:   "Apply complete!",
 				ExitCode: 0,
 			},
-			ok:       true,
-			exitCode: 0,
+			ok: true,
 		},
 	}
 
@@ -77,12 +74,9 @@ func TestNotifyApply(t *testing.T) {
 			}
 			api := newFakeAPI()
 			client.API = &api
-			exitCode, err := client.Notify.Apply(context.Background(), &testCase.paramExec)
-			if (err == nil) != testCase.ok {
+
+			if err := client.Notify.Apply(context.Background(), &testCase.paramExec); (err == nil) != testCase.ok {
 				t.Errorf("got error %v", err)
-			}
-			if exitCode != testCase.exitCode {
-				t.Errorf("got %d but want %d", exitCode, testCase.exitCode)
 			}
 		})
 	}
@@ -94,7 +88,6 @@ func TestNotifyPlan(t *testing.T) {
 		name      string
 		config    Config
 		ok        bool
-		exitCode  int
 		paramExec notifier.ParamExec
 	}{
 		{
@@ -116,8 +109,7 @@ func TestNotifyPlan(t *testing.T) {
 				Stdout:   "body",
 				ExitCode: 1,
 			},
-			ok:       true,
-			exitCode: 1,
+			ok: true,
 		},
 		{
 			name: "case 1",
@@ -138,8 +130,7 @@ func TestNotifyPlan(t *testing.T) {
 				Stdout:   "Plan: 1 to add",
 				ExitCode: 0,
 			},
-			ok:       false,
-			exitCode: 0,
+			ok: false,
 		},
 		{
 			name: "case 2",
@@ -160,8 +151,7 @@ func TestNotifyPlan(t *testing.T) {
 				Stdout:   "Error: hoge",
 				ExitCode: 1,
 			},
-			ok:       true,
-			exitCode: 1,
+			ok: true,
 		},
 		{
 			name: "case 3",
@@ -182,8 +172,7 @@ func TestNotifyPlan(t *testing.T) {
 				Stdout:   "Plan: 1 to add",
 				ExitCode: 2,
 			},
-			ok:       true,
-			exitCode: 2,
+			ok: true,
 		},
 		{
 			name: "case 4",
@@ -204,8 +193,7 @@ func TestNotifyPlan(t *testing.T) {
 				Stdout:   "Plan: 1 to add",
 				ExitCode: 2,
 			},
-			ok:       true,
-			exitCode: 2,
+			ok: true,
 		},
 		{
 			name: "case 5",
@@ -227,8 +215,7 @@ func TestNotifyPlan(t *testing.T) {
 				Stdout:   "Plan: 1 to add, 1 to destroy",
 				ExitCode: 2,
 			},
-			ok:       true,
-			exitCode: 2,
+			ok: true,
 		},
 		{
 			name: "case 6",
@@ -256,8 +243,7 @@ func TestNotifyPlan(t *testing.T) {
 				Stdout:   "No changes. Infrastructure is up-to-date.",
 				ExitCode: 0,
 			},
-			ok:       true,
-			exitCode: 0,
+			ok: true,
 		},
 		{
 			name: "case 7",
@@ -278,8 +264,7 @@ func TestNotifyPlan(t *testing.T) {
 				Stdout:   "Plan: 1 to add, 1 to destroy",
 				ExitCode: 2,
 			},
-			ok:       true,
-			exitCode: 2,
+			ok: true,
 		},
 	}
 
@@ -296,12 +281,8 @@ func TestNotifyPlan(t *testing.T) {
 			}
 			api := newFakeAPI()
 			client.API = &api
-			exitCode, err := client.Notify.Plan(context.Background(), &testCase.paramExec)
-			if (err == nil) != testCase.ok {
+			if err := client.Notify.Plan(context.Background(), &testCase.paramExec); (err == nil) != testCase.ok {
 				t.Errorf("got error %v", err)
-			}
-			if exitCode != testCase.exitCode {
-				t.Errorf("got %d but want %d", exitCode, testCase.exitCode)
 			}
 		})
 	}

--- a/pkg/notifier/localfile/apply.go
+++ b/pkg/notifier/localfile/apply.go
@@ -9,7 +9,7 @@ import (
 )
 
 // Apply posts comment optimized for notifications
-func (g *NotifyService) Apply(ctx context.Context, param *notifier.ParamExec) (int, error) {
+func (g *NotifyService) Apply(ctx context.Context, param *notifier.ParamExec) error {
 	cfg := g.client.Config
 	parser := g.client.Config.Parser
 	template := g.client.Config.Template
@@ -21,10 +21,10 @@ func (g *NotifyService) Apply(ctx context.Context, param *notifier.ParamExec) (i
 		template = g.client.Config.ParseErrorTemplate
 	} else {
 		if result.Error != nil {
-			return result.ExitCode, result.Error
+			return result.Error
 		}
 		if result.Result == "" {
-			return result.ExitCode, result.Error
+			return result.Error
 		}
 	}
 
@@ -50,7 +50,7 @@ func (g *NotifyService) Apply(ctx context.Context, param *notifier.ParamExec) (i
 	})
 	body, err := template.Execute()
 	if err != nil {
-		return result.ExitCode, err
+		return err
 	}
 
 	logE := logrus.WithFields(logrus.Fields{
@@ -59,7 +59,7 @@ func (g *NotifyService) Apply(ctx context.Context, param *notifier.ParamExec) (i
 
 	logE.Debug("write the apply result to a file")
 	if err := g.client.Output.WriteToFile(ctx, body, cfg.OutputFile); err != nil {
-		return result.ExitCode, err
+		return err
 	}
-	return result.ExitCode, nil
+	return nil
 }

--- a/pkg/notifier/localfile/plan.go
+++ b/pkg/notifier/localfile/plan.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Plan posts comment optimized for notifications
-func (g *NotifyService) Plan(ctx context.Context, param *notifier.ParamExec) (int, error) {
+func (g *NotifyService) Plan(ctx context.Context, param *notifier.ParamExec) error {
 	cfg := g.client.Config
 	parser := g.client.Config.Parser
 	template := g.client.Config.Template
@@ -22,10 +22,10 @@ func (g *NotifyService) Plan(ctx context.Context, param *notifier.ParamExec) (in
 		template = g.client.Config.ParseErrorTemplate
 	} else {
 		if result.Error != nil {
-			return result.ExitCode, result.Error
+			return result.Error
 		}
 		if result.Result == "" {
-			return result.ExitCode, result.Error
+			return result.Error
 		}
 	}
 
@@ -51,7 +51,7 @@ func (g *NotifyService) Plan(ctx context.Context, param *notifier.ParamExec) (in
 	})
 	body, err := template.Execute()
 	if err != nil {
-		return result.ExitCode, err
+		return err
 	}
 
 	logE := logrus.WithFields(logrus.Fields{
@@ -60,7 +60,7 @@ func (g *NotifyService) Plan(ctx context.Context, param *notifier.ParamExec) (in
 
 	logE.Debug("write a plan output to a file")
 	if err := g.client.Output.WriteToFile(ctx, body, cfg.OutputFile); err != nil {
-		return result.ExitCode, fmt.Errorf("write a plan output to a file: %w", err)
+		return fmt.Errorf("write a plan output to a file: %w", err)
 	}
-	return result.ExitCode, nil
+	return nil
 }

--- a/pkg/notifier/notifier.go
+++ b/pkg/notifier/notifier.go
@@ -6,8 +6,8 @@ import (
 
 // Notifier is a notification interface
 type Notifier interface {
-	Apply(ctx context.Context, param *ParamExec) (int, error)
-	Plan(ctx context.Context, param *ParamExec) (int, error)
+	Apply(ctx context.Context, param *ParamExec) error
+	Plan(ctx context.Context, param *ParamExec) error
 }
 
 type ParamExec struct {


### PR DESCRIPTION
The exit code of tfcmt should be same with the original command.