### PR TITLE
Fix fenced code blocks

### DIFF
--- a/pkg/terraform/template.go
+++ b/pkg/terraform/template.go
@@ -154,7 +154,7 @@ func wrapCode(text string) interface{} {
 	}
 	if strings.Contains(text, "```") {
 		if strings.Contains(text, "~~~") {
-			return htmltemplate.HTML(`<pre><code>` + htmltemplate.HTMLEscapeString(text) + `</code></pre>`)
+			return htmltemplate.HTML(`<pre><code>` + htmltemplate.HTMLEscapeString(text) + `</code></pre>`) //nolint:gosec
 		}
 		return htmltemplate.HTML("\n~~~hcl\n" + text + "\n~~~\n") //nolint:gosec
 	}

--- a/pkg/terraform/template.go
+++ b/pkg/terraform/template.go
@@ -153,7 +153,10 @@ func wrapCode(text string) interface{} {
 ` + text[len(text)-20000:]
 	}
 	if strings.Contains(text, "```") {
-		return htmltemplate.HTML(`<pre><code>` + htmltemplate.HTMLEscapeString(text) + `</code></pre>`)
+		if strings.Contains(text, "~~~") {
+			return htmltemplate.HTML(`<pre><code>` + htmltemplate.HTMLEscapeString(text) + `</code></pre>`)
+		}
+		return htmltemplate.HTML("\n~~~hcl\n" + text + "\n~~~\n") //nolint:gosec
 	}
 	return htmltemplate.HTML("\n```hcl\n" + text + "\n```\n") //nolint:gosec
 }

--- a/pkg/terraform/template.go
+++ b/pkg/terraform/template.go
@@ -153,7 +153,7 @@ func wrapCode(text string) interface{} {
 ` + text[len(text)-20000:]
 	}
 	if strings.Contains(text, "```") {
-		return `<pre><code>` + text + `</code></pre>`
+		return htmltemplate.HTML(`<pre><code>` + htmltemplate.HTMLEscapeString(text) + `</code></pre>`)
 	}
 	return htmltemplate.HTML("\n```hcl\n" + text + "\n```\n") //nolint:gosec
 }


### PR DESCRIPTION
When triple backticks are in results for terraform command, wrapCode method uses HTML tags(pre + code) to escape it. But currently these tags are also escaped so it doesn't work as intended.

![image](https://github.com/suzuki-shunsuke/tfcmt/assets/281261/6728502e-115c-40c5-b032-eee480f930f1)

This PR fixes the bug by
- When triple backticks are not in results, use triple backticks
- When only triple backticks are in results and triple tilde not in results, use triple tilde
- When both triple backticks and triple tilde are in results, use pre + code tags without HTML escape