### PR TITLE
fix: exit commands with non zero exit code if plan or apply fails

### DIFF
--- a/pkg/apperr/error.go
+++ b/pkg/apperr/error.go
@@ -69,11 +69,10 @@ func HandleExit(err error) int {
 				logerr.WithError(logE, err).Error("tfcmt failed")
 			}
 		}
-		code := exitErr.ExitCode()
-		if code == 0 {
-			return ExitCodeError
+		if code := exitErr.ExitCode(); code != 0 {
+			return code
 		}
-		return code
+		return ExitCodeError
 	}
 
 	logerr.WithError(logE, err).Error("tfcmt failed")

--- a/pkg/apperr/error.go
+++ b/pkg/apperr/error.go
@@ -69,7 +69,11 @@ func HandleExit(err error) int {
 				logerr.WithError(logE, err).Error("tfcmt failed")
 			}
 		}
-		return exitErr.ExitCode()
+		code := exitErr.ExitCode()
+		if code == 0 {
+			return ExitCodeError
+		}
+		return code
 	}
 
 	logerr.WithError(logE, err).Error("tfcmt failed")

--- a/pkg/apperr/error.go
+++ b/pkg/apperr/error.go
@@ -62,7 +62,8 @@ func HandleExit(err error) int {
 	logE := logrus.NewEntry(logrus.New())
 
 	if exitErr, ok := err.(ExitCoder); ok { //nolint:errorlint
-		if err.Error() != "" {
+		errMsg := err.Error()
+		if errMsg != "" {
 			if _, ok := exitErr.(ErrorFormatter); ok {
 				logrus.Errorf("%+v", err)
 			} else {
@@ -71,6 +72,9 @@ func HandleExit(err error) int {
 		}
 		if code := exitErr.ExitCode(); code != 0 {
 			return code
+		}
+		if errMsg == "" {
+			return ExitCodeOK
 		}
 		return ExitCodeError
 	}

--- a/pkg/apperr/error_test.go
+++ b/pkg/apperr/error_test.go
@@ -20,7 +20,7 @@ func TestHandleError(t *testing.T) {
 		{
 			name:     "case 1",
 			err:      NewExitError(0, errors.New("error")),
-			exitCode: 0,
+			exitCode: 1,
 		},
 		{
 			name:     "case 2",


### PR DESCRIPTION
Close #1187

This pull request changes the exit code of tfcmt when an error happens.
The exit code was same with the exit code of `terraform plan` and `terraform apply`.
This means tfcmt might have exited with zero even if tfcmt failed to post a comment due to some reason such as API rate limit.
This was not a bug but a expected behavior.
But this behaviour was dangerous because people might have missed unexpected changes.

So this pull request changes the behaviour as tfcmt exits with non zero if any error such as API rate limit happens.