### PR TITLE
feat(plan): support disabling labels by a command line option and environment variable

### DIFF
--- a/pkg/cli/app.go
+++ b/pkg/cli/app.go
@@ -81,6 +81,11 @@ $ tfcmt [<global options>] plan [-patch] [-skip-no-changes] -- terraform plan [<
 					Name:  "skip-no-changes",
 					Usage: "If there is no change tfcmt updates a label but doesn't post a comment",
 				},
+				&cli.BoolFlag{
+					Name:    "disable-label",
+					Usage:   "Disable to add or update a label",
+					EnvVars: []string{"TFCMT_DISABLE_LABEL"},
+				},
 			},
 		},
 		{

--- a/pkg/cli/var.go
+++ b/pkg/cli/var.go
@@ -81,5 +81,9 @@ func parseOpts(ctx *cli.Context, cfg *config.Config, envs []string) error { //no
 	}
 	cfg.Masks = masks
 
+	if ctx.IsSet("disable-label") {
+		cfg.Terraform.Plan.DisableLabel = ctx.Bool("disable-label")
+	}
+
 	return nil
 }


### PR DESCRIPTION
Added a command line option `-disable-label` and an environment variable `TFCMT_DISABLE_LABEL`. If they are set, `tfcmt plan` doesn't set labels.

Close #1290

```sh
tfcmt plan -disable-label -- terraform plan
```

```sh
export TFCMT_DISABLE_LABEL=true
tfcmt plan -- terraform plan
```