### PR TITLE
fix: validate if command is specified

### DIFF
--- a/pkg/controller/apply.go
+++ b/pkg/controller/apply.go
@@ -17,6 +17,9 @@ import (
 
 // Apply sends the notification with notifier
 func (ctrl *Controller) Apply(ctx context.Context, command Command) error {
+	if command.Cmd == "" {
+		return errors.New("no command specified")
+	}
 	if err := platform.Complement(&ctrl.Config); err != nil {
 		return err
 	}

--- a/pkg/controller/plan.go
+++ b/pkg/controller/plan.go
@@ -18,6 +18,9 @@ import (
 
 // Plan sends the notification with notifier
 func (ctrl *Controller) Plan(ctx context.Context, command Command) error {
+	if command.Cmd == "" {
+		return errors.New("no command specified")
+	}
 	if err := platform.Complement(&ctrl.Config); err != nil {
 		return err
 	}


### PR DESCRIPTION
`tfcmt plan` and `tfcmt apply` require command to be executed.

```sh
tfcmt plan -- terraform plan
tfcmt apply -- terraform apply
```

So this pull request adds a validation if command is specified.
If no command is specified, tfcmt plan and apply return an error immediately.

```console
$ tfcmt plan
ERRO[0000] tfcmt failed                                  error="no command specified"
```