### PR TITLE
fix: wrapCode no longer trancate long output if tfcmt outputs the result to a local file

### DIFF
--- a/pkg/notifier/localfile/apply.go
+++ b/pkg/notifier/localfile/apply.go
@@ -15,6 +15,7 @@ func (g *NotifyService) Apply(_ context.Context, param *notifier.ParamExec) erro
 	cfg := g.client.Config
 	parser := g.client.Config.Parser
 	template := g.client.Config.Template
+	template.IsLocal = true
 	var errMsgs []string
 
 	result := parser.Parse(param.CombinedOutput)

--- a/pkg/notifier/localfile/plan.go
+++ b/pkg/notifier/localfile/plan.go
@@ -15,6 +15,7 @@ func (g *NotifyService) Plan(_ context.Context, param *notifier.ParamExec) error
 	cfg := g.client.Config
 	parser := g.client.Config.Parser
 	template := g.client.Config.Template
+	template.IsLocal = true
 	var errMsgs []string
 
 	result := parser.Parse(param.CombinedOutput)


### PR DESCRIPTION
Close #1308