### PR TITLE
feat(plan): add the option `-ignore-warning`

### DIFF
--- a/pkg/cli/app.go
+++ b/pkg/cli/app.go
@@ -82,6 +82,10 @@ $ tfcmt [<global options>] plan [-patch] [-skip-no-changes] -- terraform plan [<
 					Usage: "If there is no change tfcmt updates a label but doesn't post a comment",
 				},
 				&cli.BoolFlag{
+					Name:  "ignore-warning",
+					Usage: "If skip-no-changes is enabled, comment is posted even if there is a warning. If skip-no-changes is disabled, warning is removed from the comment.",
+				},
+				&cli.BoolFlag{
 					Name:    "disable-label",
 					Usage:   "Disable to add or update a label",
 					EnvVars: []string{"TFCMT_DISABLE_LABEL"},

--- a/pkg/cli/var.go
+++ b/pkg/cli/var.go
@@ -68,6 +68,10 @@ func parseOpts(ctx *cli.Context, cfg *config.Config, envs []string) error { //no
 		cfg.Terraform.Plan.WhenNoChanges.DisableComment = ctx.Bool("skip-no-changes")
 	}
 
+	if ctx.IsSet("ignore-warning") {
+		cfg.Terraform.Plan.IgnoreWarning = ctx.Bool("ignore-warning")
+	}
+
 	vars := ctx.StringSlice("var")
 	vm := make(map[string]string, len(vars))
 	if err := parseVars(vars, envs, vm); err != nil {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -63,6 +63,7 @@ type Plan struct {
 	WhenPlanError       WhenPlanError       `yaml:"when_plan_error"`
 	WhenParseError      WhenParseError      `yaml:"when_parse_error"`
 	DisableLabel        bool                `yaml:"disable_label"`
+	IgnoreWarning       bool                `yaml:"ignore_warning"`
 }
 
 // WhenAddOrUpdateOnly is a configuration to notify the plan result contains new or updated in place resources

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -170,6 +170,7 @@ func (c *Controller) getNotifier(ctx context.Context) (notifier.Notifier, error)
 		Templates:          c.Config.Templates,
 		Patch:              c.Config.PlanPatch,
 		SkipNoChanges:      c.Config.Terraform.Plan.WhenNoChanges.DisableComment,
+		IgnoreWarning:      c.Config.Terraform.Plan.IgnoreWarning,
 		Masks:              c.Config.Masks,
 	})
 	if err != nil {

--- a/pkg/notifier/github/client.go
+++ b/pkg/notifier/github/client.go
@@ -54,6 +54,7 @@ type Config struct {
 	UseRawOutput     bool
 	Patch            bool
 	SkipNoChanges    bool
+	IgnoreWarning    bool
 	Masks            []*config.Mask
 }
 

--- a/pkg/notifier/github/plan.go
+++ b/pkg/notifier/github/plan.go
@@ -39,6 +39,10 @@ func (g *NotifyService) Plan(ctx context.Context, param *notifier.ParamExec) err
 		errMsgs = append(errMsgs, g.updateLabels(ctx, result)...)
 	}
 
+	if cfg.IgnoreWarning {
+		result.Warning = ""
+	}
+
 	template.SetValue(terraform.CommonTemplate{
 		Result:                 result.Result,
 		ChangedResult:          result.ChangedResult,


### PR DESCRIPTION
Add the option `-ignore-warning` to the `tfcmt plan` command.

By default, tfcmt emphasizes the warning of `terraform plan`, and the option `-skip-no-changes` is ignored if `terraform plan` outputs warning.

![image](https://github.com/user-attachments/assets/17aa86c8-890e-414f-b65b-6a895f5de8fb)

This is because we think warning should not be ignored.

But actually we're aware that some users ignore warning normally and they feel warning is noisy.
In this case, it's desirable that `tfcmt plan -skip-no-changes` doesn't post a comment even if warning is outputted.

So this pull request introduces a new option `-ignore-warning`.

If `terraform plan` outputs warning, this option makes the template variable `.Warning` empty, removing the warning from the default template.

If `terraform plan -skip-no-changes` has no change and outputs warning, this option disables to post a comment.