### PR TITLE
chore: remove `version` command

### DIFF
--- a/pkg/cli/app.go
+++ b/pkg/cli/app.go
@@ -107,14 +107,6 @@ $ tfcmt [<global options>] plan [-patch] [-skip-no-changes] -- terraform plan [<
 $ tfcmt [<global options>] apply -- terraform apply [<terraform apply options>]`,
 			Action: cmdApply,
 		},
-		{
-			Name:  "version",
-			Usage: "Show version",
-			Action: func(_ context.Context, ctx *cli.Command) error {
-				cli.ShowVersion(ctx)
-				return nil
-			},
-		},
 	}
 	return helpall.With(cmd, nil)
 }


### PR DESCRIPTION
For 4.14.3 release, the `tfcmt version` would print `version version`, while `tfcmt --version` prints out the right version info. It is a bit confusing to have two ways to do it, so removing version command in favor of `--version`

relates to https://github.com/chenrui333/homebrew-tap/pull/687