### PR TITLE
fix: fix version command

### DIFF
--- a/pkg/cli/app.go
+++ b/pkg/cli/app.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/suzuki-shunsuke/urfave-cli-v3-util/helpall"
+	"github.com/suzuki-shunsuke/urfave-cli-v3-util/vcmd"
 	"github.com/urfave/cli/v3"
 )
 
@@ -107,14 +108,11 @@ $ tfcmt [<global options>] plan [-patch] [-skip-no-changes] -- terraform plan [<
 $ tfcmt [<global options>] apply -- terraform apply [<terraform apply options>]`,
 			Action: cmdApply,
 		},
-		{
-			Name:  "version",
-			Usage: "Show version",
-			Action: func(_ context.Context, ctx *cli.Command) error {
-				cli.ShowVersion(ctx)
-				return nil
-			},
-		},
+		vcmd.New(&vcmd.Command{
+			Name:    "tfcmt",
+			Version: flags.Version,
+			SHA:     flags.Commit,
+		}),
 	}
 	return helpall.With(cmd, nil)
 }


### PR DESCRIPTION
```console
$ tfcmt -v
tfcmt version 4.14.4-0 (43ea3601c17774ca5dd239925705dc9f0f281828)

$ tfcmt version
tfcmt 4.14.4-0 (43ea3601c17774ca5dd239925705dc9f0f281828)
```

Hmm. `version` is missing, but this is not so problem. 😅