### PR TITLE
refactor(cli): use Destination pattern for urfave/cli/v3 flags

### DIFF
--- a/pkg/cli/app.go
+++ b/pkg/cli/app.go
@@ -8,52 +8,99 @@ import (
 	"github.com/urfave/cli/v3"
 )
 
+type GlobalArgs struct {
+	Owner    string
+	Repo     string
+	SHA      string
+	BuildURL string
+	LogLevel string
+	PR       int
+	Config   string
+	Var      []string
+	Output   string
+}
+
+type PlanArgs struct {
+	*GlobalArgs
+
+	Patch              bool
+	PatchCount         int
+	SkipNoChanges      bool
+	SkipNoChangesCount int
+	IgnoreWarning      bool
+	IgnoreWarningCount int
+	DisableLabel       bool
+	DisableLabelCount  int
+	Command            string
+	CommandArgs        []string
+}
+
+type ApplyArgs struct {
+	*GlobalArgs
+
+	Command     string
+	CommandArgs []string
+}
+
 func Run(ctx context.Context, logger *slogutil.Logger, env *urfave.Env) error {
+	globalArgs := &GlobalArgs{}
+	planArgs := &PlanArgs{GlobalArgs: globalArgs}
+	applyArgs := &ApplyArgs{GlobalArgs: globalArgs}
+
 	return urfave.Command(env, &cli.Command{ //nolint:wrapcheck
 		Name:           "tfcmt",
 		Usage:          "Notify the execution result of terraform command",
 		ExitErrHandler: func(context.Context, *cli.Command, error) {},
 		Flags: []cli.Flag{
 			&cli.StringFlag{
-				Name:    "owner",
-				Usage:   "GitHub Repository owner name",
-				Sources: cli.EnvVars("TFCMT_REPO_OWNER"),
+				Name:        "owner",
+				Usage:       "GitHub Repository owner name",
+				Sources:     cli.EnvVars("TFCMT_REPO_OWNER"),
+				Destination: &globalArgs.Owner,
 			},
 			&cli.StringFlag{
-				Name:    "repo",
-				Usage:   "GitHub Repository name",
-				Sources: cli.EnvVars("TFCMT_REPO_NAME"),
+				Name:        "repo",
+				Usage:       "GitHub Repository name",
+				Sources:     cli.EnvVars("TFCMT_REPO_NAME"),
+				Destination: &globalArgs.Repo,
 			},
 			&cli.StringFlag{
-				Name:    "sha",
-				Usage:   "commit SHA (revision)",
-				Sources: cli.EnvVars("TFCMT_SHA"),
+				Name:        "sha",
+				Usage:       "commit SHA (revision)",
+				Sources:     cli.EnvVars("TFCMT_SHA"),
+				Destination: &globalArgs.SHA,
 			},
 			&cli.StringFlag{
-				Name:  "build-url",
-				Usage: "build url",
+				Name:        "build-url",
+				Usage:       "build url",
+				Destination: &globalArgs.BuildURL,
 			},
 			&cli.StringFlag{
-				Name:  "log-level",
-				Usage: "log level",
+				Name:        "log-level",
+				Usage:       "log level",
+				Destination: &globalArgs.LogLevel,
 			},
 			&cli.IntFlag{
-				Name:    "pr",
-				Usage:   "pull request number",
-				Sources: cli.EnvVars("TFCMT_PR_NUMBER"),
+				Name:        "pr",
+				Usage:       "pull request number",
+				Sources:     cli.EnvVars("TFCMT_PR_NUMBER"),
+				Destination: &globalArgs.PR,
 			},
 			&cli.StringFlag{
-				Name:    "config",
-				Usage:   "config path",
-				Sources: cli.EnvVars("TFCMT_CONFIG"),
+				Name:        "config",
+				Usage:       "config path",
+				Sources:     cli.EnvVars("TFCMT_CONFIG"),
+				Destination: &globalArgs.Config,
 			},
 			&cli.StringSliceFlag{
-				Name:  "var",
-				Usage: "template variables. The format of value is '<name>:<value>'. You can refer to the variable in the comment and label template using {{.Vars.<variable name>}}.",
+				Name:        "var",
+				Usage:       "template variables. The format of value is '<name>:<value>'. You can refer to the variable in the comment and label template using {{.Vars.<variable name>}}.",
+				Destination: &globalArgs.Var,
 			},
 			&cli.StringFlag{
-				Name:  "output",
-				Usage: "specify file to output result instead of posting a comment",
+				Name:        "output",
+				Usage:       "specify file to output result instead of posting a comment",
+				Destination: &globalArgs.Output,
 			},
 		},
 		Commands: []*cli.Command{
@@ -64,27 +111,56 @@ func Run(ctx context.Context, logger *slogutil.Logger, env *urfave.Env) error {
 				Description: `Run terraform plan and post a comment to GitHub commit, pull request, or issue.
 
 $ tfcmt [<global options>] plan [-patch] [-skip-no-changes] -- terraform plan [<terraform plan options>]`,
-				Action: cmdPlanFunc(logger),
+				Action: func(ctx context.Context, _ *cli.Command) error {
+					return actionPlan(ctx, logger, planArgs)
+				},
 				Flags: []cli.Flag{
 					&cli.BoolFlag{
-						Name:    "patch",
-						Usage:   "update an existing comment instead of creating a new comment. If there is no existing comment, a new comment is created.",
-						Sources: cli.EnvVars("TFCMT_PLAN_PATCH"),
+						Name:        "patch",
+						Usage:       "update an existing comment instead of creating a new comment. If there is no existing comment, a new comment is created.",
+						Sources:     cli.EnvVars("TFCMT_PLAN_PATCH"),
+						Destination: &planArgs.Patch,
+						Config: cli.BoolConfig{
+							Count: &planArgs.PatchCount,
+						},
 					},
 					&cli.BoolFlag{
-						Name:    "skip-no-changes",
-						Usage:   "If there is no change tfcmt updates a label but doesn't post a comment",
-						Sources: cli.EnvVars("TFCMT_SKIP_NO_CHANGES"),
+						Name:        "skip-no-changes",
+						Usage:       "If there is no change tfcmt updates a label but doesn't post a comment",
+						Sources:     cli.EnvVars("TFCMT_SKIP_NO_CHANGES"),
+						Destination: &planArgs.SkipNoChanges,
+						Config: cli.BoolConfig{
+							Count: &planArgs.SkipNoChangesCount,
+						},
 					},
 					&cli.BoolFlag{
-						Name:    "ignore-warning",
-						Usage:   "If skip-no-changes is enabled, comment is posted even if there is a warning. If skip-no-changes is disabled, warning is removed from the comment.",
-						Sources: cli.EnvVars("TFCMT_IGNORE_WARNING"),
+						Name:        "ignore-warning",
+						Usage:       "If skip-no-changes is enabled, comment is posted even if there is a warning. If skip-no-changes is disabled, warning is removed from the comment.",
+						Sources:     cli.EnvVars("TFCMT_IGNORE_WARNING"),
+						Destination: &planArgs.IgnoreWarning,
+						Config: cli.BoolConfig{
+							Count: &planArgs.IgnoreWarningCount,
+						},
 					},
 					&cli.BoolFlag{
-						Name:    "disable-label",
-						Usage:   "Disable to add or update a label",
-						Sources: cli.EnvVars("TFCMT_DISABLE_LABEL"),
+						Name:        "disable-label",
+						Usage:       "Disable to add or update a label",
+						Sources:     cli.EnvVars("TFCMT_DISABLE_LABEL"),
+						Destination: &planArgs.DisableLabel,
+						Config: cli.BoolConfig{
+							Count: &planArgs.DisableLabelCount,
+						},
+					},
+				},
+				Arguments: []cli.Argument{
+					&cli.StringArg{
+						Name:        "command",
+						Destination: &planArgs.Command,
+					},
+					&cli.StringArgs{
+						Name:        "args",
+						Destination: &planArgs.CommandArgs,
+						Max:         -1,
 					},
 				},
 			},
@@ -95,7 +171,20 @@ $ tfcmt [<global options>] plan [-patch] [-skip-no-changes] -- terraform plan [<
 				Description: `Run terraform apply and post a comment to GitHub commit, pull request, or issue.
 
 $ tfcmt [<global options>] apply -- terraform apply [<terraform apply options>]`,
-				Action: cmdApplyFunc(logger),
+				Action: func(ctx context.Context, _ *cli.Command) error {
+					return actionApply(ctx, logger, applyArgs)
+				},
+				Arguments: []cli.Argument{
+					&cli.StringArg{
+						Name:        "command",
+						Destination: &applyArgs.Command,
+					},
+					&cli.StringArgs{
+						Name:        "args",
+						Destination: &applyArgs.CommandArgs,
+						Max:         -1,
+					},
+				},
 			},
 		},
 	}).Run(ctx, env.Args)

--- a/pkg/cli/apply.go
+++ b/pkg/cli/apply.go
@@ -8,44 +8,37 @@ import (
 	"github.com/suzuki-shunsuke/slog-util/slogutil"
 	"github.com/suzuki-shunsuke/tfcmt/v4/pkg/controller"
 	"github.com/suzuki-shunsuke/tfcmt/v4/pkg/terraform"
-	"github.com/urfave/cli/v3"
 )
 
-func cmdApplyFunc(logger *slogutil.Logger) func(ctx context.Context, cmd *cli.Command) error {
-	return func(ctx context.Context, cmd *cli.Command) error {
-		logLevel := cmd.String("log-level")
-		if err := logger.SetLevel(logLevel); err != nil {
+func actionApply(ctx context.Context, logger *slogutil.Logger, args *ApplyArgs) error {
+	if err := logger.SetLevel(args.LogLevel); err != nil {
+		return fmt.Errorf("set log level: %w", err)
+	}
+
+	cfg, err := newConfig(args.Config)
+	if err != nil {
+		return err
+	}
+
+	if args.LogLevel == "" {
+		if err := logger.SetLevel(cfg.Log.Level); err != nil {
 			return fmt.Errorf("set log level: %w", err)
 		}
-
-		cfg, err := newConfig(cmd)
-		if err != nil {
-			return err
-		}
-
-		if logLevel == "" {
-			logLevel = cfg.Log.Level
-			if err := logger.SetLevel(logLevel); err != nil {
-				return fmt.Errorf("set log level: %w", err)
-			}
-		}
-
-		if err := parseOpts(cmd, &cfg, os.Environ()); err != nil {
-			return err
-		}
-
-		t := &controller.Controller{
-			Config:             cfg,
-			Parser:             terraform.NewApplyParser(),
-			Template:           terraform.NewApplyTemplate(cfg.Terraform.Apply.Template),
-			ParseErrorTemplate: terraform.NewApplyParseErrorTemplate(cfg.Terraform.Apply.WhenParseError.Template),
-		}
-
-		args := cmd.Args()
-
-		return t.Apply(ctx, logger.Logger, controller.Command{
-			Cmd:  args.First(),
-			Args: args.Tail(),
-		})
 	}
+
+	if err := parseOptsApply(args, &cfg, os.Environ()); err != nil {
+		return err
+	}
+
+	t := &controller.Controller{
+		Config:             cfg,
+		Parser:             terraform.NewApplyParser(),
+		Template:           terraform.NewApplyTemplate(cfg.Terraform.Apply.Template),
+		ParseErrorTemplate: terraform.NewApplyParseErrorTemplate(cfg.Terraform.Apply.WhenParseError.Template),
+	}
+
+	return t.Apply(ctx, logger.Logger, controller.Command{
+		Cmd:  args.Command,
+		Args: args.CommandArgs,
+	})
 }

--- a/pkg/cli/config.go
+++ b/pkg/cli/config.go
@@ -2,12 +2,11 @@ package cli
 
 import (
 	"github.com/suzuki-shunsuke/tfcmt/v4/pkg/config"
-	"github.com/urfave/cli/v3"
 )
 
-func newConfig(cmd *cli.Command) (config.Config, error) {
+func newConfig(configPath string) (config.Config, error) {
 	cfg := config.Config{}
-	confPath, err := cfg.Find(cmd.String("config"))
+	confPath, err := cfg.Find(configPath)
 	if err != nil {
 		return cfg, err
 	}

--- a/pkg/cli/plan.go
+++ b/pkg/cli/plan.go
@@ -8,42 +8,36 @@ import (
 	"github.com/suzuki-shunsuke/slog-util/slogutil"
 	"github.com/suzuki-shunsuke/tfcmt/v4/pkg/controller"
 	"github.com/suzuki-shunsuke/tfcmt/v4/pkg/terraform"
-	"github.com/urfave/cli/v3"
 )
 
-func cmdPlanFunc(logger *slogutil.Logger) func(ctx context.Context, cmd *cli.Command) error {
-	return func(ctx context.Context, cmd *cli.Command) error {
-		logLevel := cmd.String("log-level")
-		if err := logger.SetLevel(logLevel); err != nil {
+func actionPlan(ctx context.Context, logger *slogutil.Logger, args *PlanArgs) error {
+	if err := logger.SetLevel(args.LogLevel); err != nil {
+		return fmt.Errorf("set log level: %w", err)
+	}
+
+	cfg, err := newConfig(args.Config)
+	if err != nil {
+		return err
+	}
+	if args.LogLevel == "" {
+		if err := logger.SetLevel(cfg.Log.Level); err != nil {
 			return fmt.Errorf("set log level: %w", err)
 		}
-
-		cfg, err := newConfig(cmd)
-		if err != nil {
-			return err
-		}
-		if logLevel == "" {
-			logLevel = cfg.Log.Level
-			if err := logger.SetLevel(logLevel); err != nil {
-				return fmt.Errorf("set log level: %w", err)
-			}
-		}
-
-		if err := parseOpts(cmd, &cfg, os.Environ()); err != nil {
-			return err
-		}
-
-		t := &controller.Controller{
-			Config:             cfg,
-			Parser:             terraform.NewPlanParser(),
-			Template:           terraform.NewPlanTemplate(cfg.Terraform.Plan.Template),
-			ParseErrorTemplate: terraform.NewPlanParseErrorTemplate(cfg.Terraform.Plan.WhenParseError.Template),
-		}
-		args := cmd.Args()
-
-		return t.Plan(ctx, logger.Logger, controller.Command{
-			Cmd:  args.First(),
-			Args: args.Tail(),
-		})
 	}
+
+	if err := parseOptsPlan(args, &cfg, os.Environ()); err != nil {
+		return err
+	}
+
+	t := &controller.Controller{
+		Config:             cfg,
+		Parser:             terraform.NewPlanParser(),
+		Template:           terraform.NewPlanTemplate(cfg.Terraform.Plan.Template),
+		ParseErrorTemplate: terraform.NewPlanParseErrorTemplate(cfg.Terraform.Plan.WhenParseError.Template),
+	}
+
+	return t.Plan(ctx, logger.Logger, controller.Command{
+		Cmd:  args.Command,
+		Args: args.CommandArgs,
+	})
 }


### PR DESCRIPTION
- Define GlobalArgs, PlanArgs, ApplyArgs structs to hold flag values
- Use Destination field to bind flag values directly to struct fields
- Use Arguments to capture positional args instead of cmd.Args()
- Use BoolConfig.Count to detect if boolean flags were explicitly set
- Simplify action functions by removing closure wrappers

🤖 Generated with [Claude Code](https://claude.com/claude-code)