### PR TITLE
feat: add stripLines template helper for filtering noisy plan output

### DIFF
--- a/pkg/terraform/template.go
+++ b/pkg/terraform/template.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	htmltemplate "html/template"
 	"maps"
+	"regexp"
 	"strings"
 	texttemplate "text/template"
 
@@ -144,6 +145,27 @@ func avoidHTMLEscape(text string) htmltemplate.HTML {
 	return htmltemplate.HTML(text) //nolint:gosec
 }
 
+// stripLines removes lines from text whose content matches the given regular
+// expression. The pattern uses Go's regexp/syntax. A line is removed when the
+// pattern matches anywhere in the line, mirroring `grep -v`.
+//
+// Intended for use in templates to filter verbose noise from .CombinedOutput
+// (for example "Refreshing state..." lines) before passing it to wrapCode.
+func stripLines(pattern, text string) (string, error) {
+	re, err := regexp.Compile(pattern)
+	if err != nil {
+		return "", err
+	}
+	lines := strings.Split(text, "\n")
+	kept := make([]string, 0, len(lines))
+	for _, line := range lines {
+		if !re.MatchString(line) {
+			kept = append(kept, line)
+		}
+	}
+	return strings.Join(kept, "\n"), nil
+}
+
 func wrapCode(text string) any {
 	header := ""
 	if len(text) > 60000 { //nolint:mnd
@@ -172,6 +194,7 @@ func generateOutput(kind, template string, data map[string]any, useRawOutput boo
 	if useRawOutput {
 		tpl, err := texttemplate.New(kind).Funcs(texttemplate.FuncMap{
 			"avoidHTMLEscape": avoidHTMLEscape,
+			"stripLines":      stripLines,
 			"wrapCode":        wrapCode,
 		}).Funcs(tmpl.TxtFuncMap()).Parse(template)
 		if err != nil {
@@ -183,6 +206,7 @@ func generateOutput(kind, template string, data map[string]any, useRawOutput boo
 	} else {
 		tpl, err := htmltemplate.New(kind).Funcs(htmltemplate.FuncMap{
 			"avoidHTMLEscape": avoidHTMLEscape,
+			"stripLines":      stripLines,
 			"wrapCode":        wrapCode,
 		}).Funcs(tmpl.FuncMap()).Parse(template)
 		if err != nil {

--- a/pkg/terraform/template_test.go
+++ b/pkg/terraform/template_test.go
@@ -1,29 +1,30 @@
 package terraform
 
 import (
-	"strings"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestStripLines(t *testing.T) {
 	t.Parallel()
-	cases := []struct {
-		name    string
-		pattern string
-		input   string
-		want    string
+	testCases := []struct {
+		name     string
+		pattern  string
+		input    string
+		expected string
 	}{
 		{
-			name:    "empty input",
-			pattern: "anything",
-			input:   "",
-			want:    "",
+			name:     "empty input",
+			pattern:  "anything",
+			input:    "",
+			expected: "",
 		},
 		{
-			name:    "no matches keeps input intact",
-			pattern: "Refreshing state",
-			input:   "line a\nline b\nline c",
-			want:    "line a\nline b\nline c",
+			name:     "no matches keeps input intact",
+			pattern:  "Refreshing state",
+			input:    "line a\nline b\nline c",
+			expected: "line a\nline b\nline c",
 		},
 		{
 			name:    "matching lines removed, others kept",
@@ -33,51 +34,50 @@ google_project.my_project: Refreshing state... [id=my-project]
 aws_iam_user.alice: Read complete after 0s [id=alice]
 
 Plan: 1 to add, 0 to change, 0 to destroy.`,
-			want: `aws_iam_user.alice: Read complete after 0s [id=alice]
+			expected: `aws_iam_user.alice: Read complete after 0s [id=alice]
 
 Plan: 1 to add, 0 to change, 0 to destroy.`,
 		},
 		{
-			name:    "all lines match yields empty result",
-			pattern: "x",
-			input:   "x\nxx\nxxx",
-			want:    "",
+			name:     "all lines match yields empty result",
+			pattern:  "x",
+			input:    "x\nxx\nxxx",
+			expected: "",
 		},
 		{
-			name:    "trailing newline preserved when last line is empty",
-			pattern: "drop",
-			input:   "drop me\nkeep me\n",
-			want:    "keep me\n",
+			name:     "trailing newline preserved when last line is empty",
+			pattern:  "drop",
+			input:    "drop me\nkeep me\n",
+			expected: "keep me\n",
 		},
 		{
-			name:    "anchored pattern matches only at line start",
-			pattern: "^Refreshing",
-			input:   "Refreshing state...\nfoo: Refreshing state...\nkeep",
-			want:    "foo: Refreshing state...\nkeep",
+			name:     "anchored pattern matches only at line start",
+			pattern:  "^Refreshing",
+			input:    "Refreshing state...\nfoo: Refreshing state...\nkeep",
+			expected: "foo: Refreshing state...\nkeep",
 		},
 		{
-			name:    "regex special characters work as Go regexp",
-			pattern: `Refreshing state\.\.\.`,
-			input:   "a: Refreshing state...\nb: refreshing state (not dots)\nc",
-			want:    "b: refreshing state (not dots)\nc",
+			name:     "regex special characters work as Go regexp",
+			pattern:  `Refreshing state\.\.\.`,
+			input:    "a: Refreshing state...\nb: refreshing state (not dots)\nc",
+			expected: "b: refreshing state (not dots)\nc",
 		},
 		{
-			name:    "carriage returns preserved",
-			pattern: "drop",
-			input:   "drop me\r\nkeep me\r\n",
-			want:    "keep me\r\n",
+			name:     "carriage returns preserved",
+			pattern:  "drop",
+			input:    "drop me\r\nkeep me\r\n",
+			expected: "keep me\r\n",
 		},
 	}
-
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
-			got, err := stripLines(tc.pattern, tc.input)
+			actual, err := stripLines(testCase.pattern, testCase.input)
 			if err != nil {
-				t.Fatalf("stripLines returned error: %v", err)
+				t.Fatalf("stripLines returned an unexpected error: %v", err)
 			}
-			if got != tc.want {
-				t.Errorf("stripLines(%q, %q):\nwant %q\n got %q", tc.pattern, tc.input, tc.want, got)
+			if diff := cmp.Diff(actual, testCase.expected); diff != "" {
+				t.Error(diff)
 			}
 		})
 	}
@@ -85,14 +85,13 @@ Plan: 1 to add, 0 to change, 0 to destroy.`,
 
 func TestStripLinesInvalidPattern(t *testing.T) {
 	t.Parallel()
-	_, err := stripLines("(unclosed", "anything")
-	if err == nil {
+	if _, err := stripLines("(unclosed", "anything"); err == nil {
 		t.Fatal("expected error for invalid regexp pattern, got nil")
 	}
 }
 
-// TestStripLinesInTemplate verifies the helper is registered in the template
-// FuncMap and can be chained with wrapCode in a realistic plan template.
+// TestStripLinesInTemplate verifies stripLines is registered in the html/template
+// FuncMap (the default flow) and can be chained with wrapCode.
 func TestStripLinesInTemplate(t *testing.T) {
 	t.Parallel()
 	tpl := NewPlanTemplate(`{{ stripLines "Refreshing state" .CombinedOutput | wrapCode }}`)
@@ -102,24 +101,18 @@ aws_iam_user.alice: Refreshing state... [id=alice]
 Plan: 0 to add, 1 to change, 0 to destroy.`,
 	})
 
-	got, err := tpl.Execute()
+	actual, err := tpl.Execute()
 	if err != nil {
 		t.Fatalf("template execution failed: %v", err)
 	}
-
-	if strings.Contains(got, "Refreshing state") {
-		t.Errorf("expected `Refreshing state` lines to be stripped, got:\n%s", got)
-	}
-	if !strings.Contains(got, "Plan: 0 to add, 1 to change, 0 to destroy.") {
-		t.Errorf("expected Plan summary line to survive, got:\n%s", got)
-	}
-	if !strings.Contains(got, "```hcl") {
-		t.Errorf("expected wrapCode to fence the result with ```hcl, got:\n%s", got)
+	expected := "\n```hcl\nPlan: 0 to add, 1 to change, 0 to destroy.\n```\n"
+	if diff := cmp.Diff(actual, expected); diff != "" {
+		t.Error(diff)
 	}
 }
 
-// TestStripLinesInRawTemplate verifies the helper works in the text/template
-// flow used when UseRawOutput is true.
+// TestStripLinesInRawTemplate verifies stripLines is registered in the
+// text/template FuncMap used when UseRawOutput is true.
 func TestStripLinesInRawTemplate(t *testing.T) {
 	t.Parallel()
 	tpl := NewPlanTemplate(`{{ stripLines "noisy" .CombinedOutput }}`)
@@ -128,14 +121,12 @@ func TestStripLinesInRawTemplate(t *testing.T) {
 		CombinedOutput: "keep\nnoisy line\nkeep",
 	})
 
-	got, err := tpl.Execute()
+	actual, err := tpl.Execute()
 	if err != nil {
 		t.Fatalf("template execution failed: %v", err)
 	}
-	if strings.Contains(got, "noisy line") {
-		t.Errorf("expected noisy line to be stripped, got:\n%s", got)
-	}
-	if !strings.Contains(got, "keep\nkeep") {
-		t.Errorf("expected kept lines to be adjacent after strip, got:\n%s", got)
+	expected := "keep\nkeep"
+	if diff := cmp.Diff(actual, expected); diff != "" {
+		t.Error(diff)
 	}
 }

--- a/pkg/terraform/template_test.go
+++ b/pkg/terraform/template_test.go
@@ -1,0 +1,141 @@
+package terraform
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestStripLines(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name    string
+		pattern string
+		input   string
+		want    string
+	}{
+		{
+			name:    "empty input",
+			pattern: "anything",
+			input:   "",
+			want:    "",
+		},
+		{
+			name:    "no matches keeps input intact",
+			pattern: "Refreshing state",
+			input:   "line a\nline b\nline c",
+			want:    "line a\nline b\nline c",
+		},
+		{
+			name:    "matching lines removed, others kept",
+			pattern: "Refreshing state",
+			input: `data.terraform_remote_state.foo: Refreshing state...
+google_project.my_project: Refreshing state... [id=my-project]
+aws_iam_user.alice: Read complete after 0s [id=alice]
+
+Plan: 1 to add, 0 to change, 0 to destroy.`,
+			want: `aws_iam_user.alice: Read complete after 0s [id=alice]
+
+Plan: 1 to add, 0 to change, 0 to destroy.`,
+		},
+		{
+			name:    "all lines match yields empty result",
+			pattern: "x",
+			input:   "x\nxx\nxxx",
+			want:    "",
+		},
+		{
+			name:    "trailing newline preserved when last line is empty",
+			pattern: "drop",
+			input:   "drop me\nkeep me\n",
+			want:    "keep me\n",
+		},
+		{
+			name:    "anchored pattern matches only at line start",
+			pattern: "^Refreshing",
+			input:   "Refreshing state...\nfoo: Refreshing state...\nkeep",
+			want:    "foo: Refreshing state...\nkeep",
+		},
+		{
+			name:    "regex special characters work as Go regexp",
+			pattern: `Refreshing state\.\.\.`,
+			input:   "a: Refreshing state...\nb: refreshing state (not dots)\nc",
+			want:    "b: refreshing state (not dots)\nc",
+		},
+		{
+			name:    "carriage returns preserved",
+			pattern: "drop",
+			input:   "drop me\r\nkeep me\r\n",
+			want:    "keep me\r\n",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := stripLines(tc.pattern, tc.input)
+			if err != nil {
+				t.Fatalf("stripLines returned error: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("stripLines(%q, %q):\nwant %q\n got %q", tc.pattern, tc.input, tc.want, got)
+			}
+		})
+	}
+}
+
+func TestStripLinesInvalidPattern(t *testing.T) {
+	t.Parallel()
+	_, err := stripLines("(unclosed", "anything")
+	if err == nil {
+		t.Fatal("expected error for invalid regexp pattern, got nil")
+	}
+}
+
+// TestStripLinesInTemplate verifies the helper is registered in the template
+// FuncMap and can be chained with wrapCode in a realistic plan template.
+func TestStripLinesInTemplate(t *testing.T) {
+	t.Parallel()
+	tpl := NewPlanTemplate(`{{ stripLines "Refreshing state" .CombinedOutput | wrapCode }}`)
+	tpl.SetValue(CommonTemplate{
+		CombinedOutput: `data.terraform_remote_state.foo: Refreshing state...
+aws_iam_user.alice: Refreshing state... [id=alice]
+Plan: 0 to add, 1 to change, 0 to destroy.`,
+	})
+
+	got, err := tpl.Execute()
+	if err != nil {
+		t.Fatalf("template execution failed: %v", err)
+	}
+
+	if strings.Contains(got, "Refreshing state") {
+		t.Errorf("expected `Refreshing state` lines to be stripped, got:\n%s", got)
+	}
+	if !strings.Contains(got, "Plan: 0 to add, 1 to change, 0 to destroy.") {
+		t.Errorf("expected Plan summary line to survive, got:\n%s", got)
+	}
+	if !strings.Contains(got, "```hcl") {
+		t.Errorf("expected wrapCode to fence the result with ```hcl, got:\n%s", got)
+	}
+}
+
+// TestStripLinesInRawTemplate verifies the helper works in the text/template
+// flow used when UseRawOutput is true.
+func TestStripLinesInRawTemplate(t *testing.T) {
+	t.Parallel()
+	tpl := NewPlanTemplate(`{{ stripLines "noisy" .CombinedOutput }}`)
+	tpl.SetValue(CommonTemplate{
+		UseRawOutput:   true,
+		CombinedOutput: "keep\nnoisy line\nkeep",
+	})
+
+	got, err := tpl.Execute()
+	if err != nil {
+		t.Fatalf("template execution failed: %v", err)
+	}
+	if strings.Contains(got, "noisy line") {
+		t.Errorf("expected noisy line to be stripped, got:\n%s", got)
+	}
+	if !strings.Contains(got, "keep\nkeep") {
+		t.Errorf("expected kept lines to be adjacent after strip, got:\n%s", got)
+	}
+}

--- a/website/docs/config.md
+++ b/website/docs/config.md
@@ -76,9 +76,26 @@ In the template, the [sprig template functions](http://masterminds.github.io/spr
 And the following functions can be used.
 
 * avoidHTMLEscape
+* stripLines
 * wrapCode
 
 `avoidHTMLEscape` prevents the text from being HTML escaped.
+
+`stripLines` removes lines that match a [Go regular expression](https://pkg.go.dev/regexp/syntax) from a string. A line is removed when the pattern matches anywhere in the line, mirroring `grep -v`. Use it to filter verbose noise from `.CombinedOutput` (for example, `Refreshing state...` lines from `terraform plan`) before passing to `wrapCode`:
+
+```yaml
+terraform:
+  plan:
+    template: |
+      {{template "plan_title" .}}
+      {{template "result" .}}
+
+      <details><summary>Details (Click me)</summary>
+      {{ stripLines "Refreshing state" .CombinedOutput | wrapCode }}
+      </details>
+```
+
+`stripLines` returns an error if the pattern is not a valid Go regular expression, which surfaces as a template execution error.
 
 `wrapCode` wraps a test with <code>\`\`\`</code> or `<pre><code>`.
 If the text includes <code>\`\`\`</code>, the text wraps with `<pre><code>`, otherwise the text wraps with <code>\`\`\`</code> and the text isn't HTML escaped.


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [Write a GitHub Issue before creating a Pull Request](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md#create-an-issue-before-creating-a-pull-request)
  - Link to the issue: #2326
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request

<!-- Please write the description here -->

## Summary

Adds a `stripLines(pattern, text)` template helper that removes lines matching a Go regular expression. Registered next to `wrapCode` and `avoidHTMLEscape` in both the `text/template` (UseRawOutput) and `html/template` flows.

Closes #2326.

## Motivation

For plans with many resources, `.CombinedOutput` includes a large volume of `Refreshing state...` log lines from Terraform. They render inside the default `<details>` block alongside the actual diff, often >200 chars per line with embedded resource IDs, and make plan comments harder to skim. Today the only way to filter them out is to replace the entire `plan` template, which orgs that use tfcmt globally usually want to avoid (cf. #1982).

`stripLines` lets users keep the default templates and slot in a regex filter where needed:

```yaml
terraform:
  plan:
    template: |
      {{template "plan_title" .}}
      {{template "result" .}}

      <details><summary>Details (Click me)</summary>
      {{ stripLines "Refreshing state" .CombinedOutput | wrapCode }}
      </details>
```

Generalises beyond refresh-state — any regex can be used to drop lines.

## Implementation

Thin wrapper over `regexp.Compile` + a line-by-line filter. Errors from invalid patterns surface as template execution errors, consistent with how Go templates handle helper errors elsewhere.

Files touched:

- `pkg/terraform/template.go` — +24 lines (regexp import, helper, two FuncMap entries next to `wrapCode`)
- `pkg/terraform/template_test.go` — new, 11 cases (8 unit, 1 invalid-pattern, 2 template integration). Style matches `parser_test.go` (`testCases` / `expected` / `cmp.Diff`).
- `website/docs/config.md` — entry under Template Functions with a worked example.

Additive only. No defaults changed; templates that don't reference `stripLines` render identically to before.

The PR contains two commits (no force-push after opening):

1. `feat: add stripLines template helper for filtering noisy plan output`
2. `test: align stripLines tests with package conventions`

## Verification

```console
$ go test ./...
ok across 12 packages, 76 tests

$ golangci-lint run ./...
0 issues

$ go vet ./...
0 issues

$ gofmt -l pkg/terraform/
(no output)
```

## AI usage

Drafted with assistance from an LLM agent (Claude). I reviewed the implementation line-by-line, ran the local test suite and linter, and own the design choices and the resulting code.