### PR TITLE
fix: don't append the run attempt to the build URL if GITHUB_RUN_ATTEMPT is empty

### DIFF
--- a/pkg/platform/ci.go
+++ b/pkg/platform/ci.go
@@ -48,13 +48,19 @@ func getLink(ciname string) string {
 	case "codebuild":
 		return os.Getenv("CODEBUILD_BUILD_URL")
 	case "github-actions":
-		return fmt.Sprintf(
-			"%s/%s/actions/runs/%s/attempts/%s",
+		link := fmt.Sprintf(
+			"%s/%s/actions/runs/%s",
 			os.Getenv("GITHUB_SERVER_URL"),
 			os.Getenv("GITHUB_REPOSITORY"),
 			os.Getenv("GITHUB_RUN_ID"),
-			os.Getenv("GITHUB_RUN_ATTEMPT"),
 		)
+		// GITHUB_RUN_ATTEMPT isn't always available.
+		// e.g. GitHub Enterprise Server < 3.3, GitHub Actions compatible runners.
+		// The URL would be broken if the attempt were empty.
+		if attempt := os.Getenv("GITHUB_RUN_ATTEMPT"); attempt != "" {
+			link += "/attempts/" + attempt
+		}
+		return link
 	case "google-cloud-build":
 		region := os.Getenv("_REGION")
 		if region == "" {

--- a/pkg/platform/ci_internal_test.go
+++ b/pkg/platform/ci_internal_test.go
@@ -1,0 +1,94 @@
+package platform
+
+import (
+	"testing"
+)
+
+func TestGetLink(t *testing.T) {
+	const (
+		circleCI         = "circleci"
+		codeBuild        = "codebuild"
+		gitHubActions    = "github-actions"
+		googleCloudBuild = "google-cloud-build"
+	)
+	testCases := []struct {
+		name   string
+		ciname string
+		env    map[string]string
+		exp    string
+	}{
+		{
+			name:   "github actions",
+			ciname: gitHubActions,
+			env: map[string]string{
+				"GITHUB_SERVER_URL":  "https://github.com",
+				"GITHUB_REPOSITORY":  "suzuki-shunsuke/tfcmt",
+				"GITHUB_RUN_ID":      "1",
+				"GITHUB_RUN_ATTEMPT": "2",
+			},
+			exp: "https://github.com/suzuki-shunsuke/tfcmt/actions/runs/1/attempts/2",
+		},
+		{
+			name:   "github actions without run attempt",
+			ciname: gitHubActions,
+			env: map[string]string{
+				"GITHUB_SERVER_URL":  "https://github.com",
+				"GITHUB_REPOSITORY":  "suzuki-shunsuke/tfcmt",
+				"GITHUB_RUN_ID":      "1",
+				"GITHUB_RUN_ATTEMPT": "",
+			},
+			exp: "https://github.com/suzuki-shunsuke/tfcmt/actions/runs/1",
+		},
+		{
+			name:   "circle ci",
+			ciname: circleCI,
+			env: map[string]string{
+				"CIRCLE_BUILD_URL": "https://circleci.com/gh/suzuki-shunsuke/tfcmt/1",
+			},
+			exp: "https://circleci.com/gh/suzuki-shunsuke/tfcmt/1",
+		},
+		{
+			name:   "code build",
+			ciname: codeBuild,
+			env: map[string]string{
+				"CODEBUILD_BUILD_URL": "https://console.aws.amazon.com/codebuild/home",
+			},
+			exp: "https://console.aws.amazon.com/codebuild/home",
+		},
+		{
+			name:   "google cloud build",
+			ciname: googleCloudBuild,
+			env: map[string]string{
+				"_REGION":    "asia-northeast1",
+				"BUILD_ID":   "1",
+				"PROJECT_ID": "foo",
+			},
+			exp: "https://console.cloud.google.com/cloud-build/builds;region=asia-northeast1/1?project=foo",
+		},
+		{
+			name:   "google cloud build without region",
+			ciname: googleCloudBuild,
+			env: map[string]string{
+				"_REGION":    "",
+				"BUILD_ID":   "1",
+				"PROJECT_ID": "foo",
+			},
+			exp: "https://console.cloud.google.com/cloud-build/builds;region=global/1?project=foo",
+		},
+		{
+			name:   "unknown ci",
+			ciname: "unknown",
+			exp:    "",
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			for k, v := range testCase.env {
+				t.Setenv(k, v)
+			}
+			if link := getLink(testCase.ciname); link != testCase.exp {
+				t.Fatalf("got %q but want %q", link, testCase.exp)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Overview

Follow up to #2414.

#2414 changed the GitHub Actions build URL to `{server}/{repo}/actions/runs/{run_id}/attempts/{run_attempt}` so that a comment keeps linking to the attempt it was posted from, instead of always redirecting to the latest attempt. That's right, but the attempt is appended unconditionally.

`GITHUB_RUN_ATTEMPT` isn't always set. go-ci-env detects GitHub Actions by `GITHUB_ACTIONS=true` alone, so environments such as GitHub Enterprise Server older than 3.3 and GitHub Actions compatible runners can reach this code without `GITHUB_RUN_ATTEMPT`. In that case the generated URL ends with `/attempts/`, which returns 404:

```
.../actions/runs/29806812528            -> 200
.../actions/runs/29806812528/attempts/1 -> 200
.../actions/runs/29806812528/attempts/  -> 404
```

Before #2414 those environments got a working link, so this is a regression for them.

## Changes

- Append `/attempts/{run_attempt}` only when `GITHUB_RUN_ATTEMPT` isn't empty
- Add `pkg/platform/ci_internal_test.go` covering `getLink` for each CI platform, including GitHub Actions with and without `GITHUB_RUN_ATTEMPT`

The behaviour on GitHub Actions itself is unchanged: `GITHUB_RUN_ATTEMPT` is set there, so the URL still points at the current attempt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)