### PR TITLE
fix: treat import only plans as no changes

### DIFF
--- a/pkg/terraform/parser.go
+++ b/pkg/terraform/parser.go
@@ -68,8 +68,10 @@ func NewPlanParser() *PlanParser {
 		OutputsChanges: regexp.MustCompile(`(?m)^Changes to Outputs:`),
 		// "0 to destroy" should be treated as "no destroy"
 		HasDestroy: regexp.MustCompile(`(?m)([1-9][0-9]* to destroy.)`),
-		// "0 to add, 0 to change, 0 to destroy" should be treated as "no change" (issue#358)
-		HasNoChanges:       regexp.MustCompile(`(?m)^(No changes\.|Plan: 0 to add, 0 to change, 0 to destroy\.)`),
+		// "0 to add, 0 to change, 0 to destroy" should be treated as "no change" (issue#358).
+		// Terraform prefixes the summary with "N to import" only when the plan imports resources,
+		// and an import changes only the state, so it should be treated as "no change" too.
+		HasNoChanges:       regexp.MustCompile(`(?m)^(No changes\.|Plan: (\d+ to import, )?0 to add, 0 to change, 0 to destroy\.)`),
 		Create:             regexp.MustCompile(`^ *# (.*) will be created$`),
 		Update:             regexp.MustCompile(`^ *# (.*) will be updated in-place$`),
 		Delete:             regexp.MustCompile(`^ *# (.*) will be destroyed$`),

--- a/pkg/terraform/parser_test.go
+++ b/pkg/terraform/parser_test.go
@@ -490,6 +490,60 @@ Note: You didn't use the -out option to save this plan, so Terraform can't
 guarantee to take exactly these actions if you run "terraform apply" now.
 `
 
+const planImportOnly = `
+github_repository.tfcmt: Preparing import... [id=tfcmt]
+github_repository.tfcmt: Refreshing state... [id=tfcmt]
+
+Terraform will perform the following actions:
+
+  # github_repository.tfcmt will be imported
+    resource "github_repository" "tfcmt" {
+        id   = "tfcmt"
+        name = "tfcmt"
+    }
+
+Plan: 1 to import, 0 to add, 0 to change, 0 to destroy.
+
+─────────────────────────────────────────────────────────────────────────────
+
+Note: You didn't use the -out option to save this plan, so Terraform can't
+guarantee to take exactly these actions if you run "terraform apply" now.
+`
+
+const planImportedAndMovedOnly = `
+null_resource.bar: Refreshing state... [id=7822522400686116714]
+github_repository.tfaction: Preparing import... [id=tfaction]
+github_repository.tfaction: Refreshing state... [id=tfaction]
+github_repository.tfcmt: Preparing import... [id=tfcmt]
+github_repository.tfcmt: Refreshing state... [id=tfcmt]
+
+Terraform will perform the following actions:
+
+  # github_repository.tfaction will be imported
+    resource "github_repository" "tfaction" {
+        id   = "tfaction"
+        name = "tfaction"
+    }
+
+  # github_repository.tfcmt will be imported
+    resource "github_repository" "tfcmt" {
+        id   = "tfcmt"
+        name = "tfcmt"
+    }
+
+  # null_resource.foo has moved to null_resource.bar
+    resource "null_resource" "bar" {
+        id = "7822522400686116714"
+    }
+
+Plan: 2 to import, 0 to add, 0 to change, 0 to destroy.
+
+─────────────────────────────────────────────────────────────────────────────
+
+Note: You didn't use the -out option to save this plan, so Terraform can't
+guarantee to take exactly these actions if you run "terraform apply" now.
+`
+
 const applySuccessResult = `
 data.terraform_remote_state.teams_platform_development: Refreshing state...
 google_project.my_service: Refreshing state...
@@ -935,6 +989,70 @@ Plan: 1 to import, 2 to add, 2 to change, 1 to destroy.`,
     }
 
 Plan: 2 to add, 1 to change, 2 to destroy.`,
+			},
+		},
+		{
+			name: "plan imports resources only",
+			body: planImportOnly,
+			result: ParseResult{
+				Result:             "Plan: 1 to import, 0 to add, 0 to change, 0 to destroy.",
+				HasAddOrUpdateOnly: false,
+				HasDestroy:         false,
+				HasNoChanges:       true,
+				HasError:           false,
+				Error:              nil,
+				ImportedResources: []string{
+					"github_repository.tfcmt",
+				},
+				ChangedResult: `
+  # github_repository.tfcmt will be imported
+    resource "github_repository" "tfcmt" {
+        id   = "tfcmt"
+        name = "tfcmt"
+    }
+
+Plan: 1 to import, 0 to add, 0 to change, 0 to destroy.`,
+			},
+		},
+		{
+			name: "plan imports and moves resources only",
+			body: planImportedAndMovedOnly,
+			result: ParseResult{
+				Result:             "Plan: 2 to import, 0 to add, 0 to change, 0 to destroy.",
+				HasAddOrUpdateOnly: false,
+				HasDestroy:         false,
+				HasNoChanges:       true,
+				HasError:           false,
+				Error:              nil,
+				ImportedResources: []string{
+					"github_repository.tfaction",
+					"github_repository.tfcmt",
+				},
+				MovedResources: []*MovedResource{
+					{
+						Before: "null_resource.foo",
+						After:  "null_resource.bar",
+					},
+				},
+				ChangedResult: `
+  # github_repository.tfaction will be imported
+    resource "github_repository" "tfaction" {
+        id   = "tfaction"
+        name = "tfaction"
+    }
+
+  # github_repository.tfcmt will be imported
+    resource "github_repository" "tfcmt" {
+        id   = "tfcmt"
+        name = "tfcmt"
+    }
+
+  # null_resource.foo has moved to null_resource.bar
+    resource "null_resource" "bar" {
+        id = "7822522400686116714"
+    }
+
+Plan: 2 to import, 0 to add, 0 to change, 0 to destroy.`,
 			},
 		},
 	}


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [Write a GitHub Issue before creating a Pull Request](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md#create-an-issue-before-creating-a-pull-request)
  - Link to the issue: #2456
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request

## What

Classify an import-only plan the same way as a move-only plan.

`HasNoChanges` now also matches `Plan: N to import, 0 to add, 0 to change, 0 to destroy.`, which Terraform prints when the plan imports resources. Plans that import *and* change resources (`Plan: 1 to import, 2 to add, ...`) are unaffected.

## Why

Since #1871, `Plan: 0 to add, 0 to change, 0 to destroy.` is classified as `no-changes`, so a plan containing only `moved` blocks gets the `no-changes` label. An import-only plan is the same class of change — the state changes, but the infrastructure doesn't — yet it gets `add-or-update` today, only because Terraform prefixes the summary line with `N to import`.

```console
$ tfcmt plan -- terraform plan
Terraform will perform the following actions:

  # github_repository.tfcmt will be imported
    resource "github_repository" "tfcmt" {
        id   = "tfcmt"
        name = "tfcmt"
    }

Plan: 1 to import, 0 to add, 0 to change, 0 to destroy.
```

The goal is consistency between imports and moves, not a change to the classification itself. This PR simply follows the current behaviour from #1871.

## Note

- Closes #2456
- Related: #358, #1871, #1896, #1907, #2404.
- Whether this category should be classified as `no-changes` at all is a separate discussion — #2404 asks for an opt-in way to distinguish it, since these plans still require `terraform apply`. If that classification is revisited, imports should be covered by whatever the new behaviour is, together with moves. This PR doesn't change that discussion.
