### PR TITLE
fix: adapt to the go-github v90 label API

### DIFF
--- a/pkg/notifier/github/github.go
+++ b/pkg/notifier/github/github.go
@@ -50,9 +50,9 @@ func (g *GitHub) IssuesRemoveLabel(ctx context.Context, number int, label string
 	return g.Issues.RemoveLabelForIssue(ctx, g.owner, g.repo, number, label)
 }
 
-// IssuesUpdateLabel is a wrapper of https://pkg.go.dev/github.com/google/go-github/github#IssuesService.EditLabel
+// IssuesUpdateLabel is a wrapper of https://pkg.go.dev/github.com/google/go-github/github#IssuesService.UpdateLabel
 func (g *GitHub) IssuesUpdateLabel(ctx context.Context, label, color string) (*github.Label, *github.Response, error) {
-	return g.Issues.EditLabel(ctx, g.owner, g.repo, label, &github.Label{
+	return g.Issues.UpdateLabel(ctx, g.owner, g.repo, label, github.UpdateIssueLabelRequest{
 		Color: &color,
 	})
 }

--- a/pkg/notifier/github/github_test.go
+++ b/pkg/notifier/github/github_test.go
@@ -64,12 +64,12 @@ func newFakeAPI() fakeAPI {
 		FakeIssuesListLabels: func(ctx context.Context, number int, opts *github.ListOptions) ([]*github.Label, *github.Response, error) {
 			labels := []*github.Label{
 				{
-					ID:   new(int64(371748792)),
-					Name: new("label 1"),
+					ID:   371748792,
+					Name: "label 1",
 				},
 				{
-					ID:   new(int64(371765743)),
-					Name: new("label 2"),
+					ID:   371765743,
+					Name: "label 2",
 				},
 			}
 			return labels, nil, nil


### PR DESCRIPTION
Fixes the CI failure on #2444 so that go-github v90 can be merged.

go-github v90 makes two breaking changes that this repository hits:

1. `IssuesService.EditLabel` is gone, replaced by `UpdateLabel`, which takes an
   `UpdateIssueLabelRequest` value instead of a `*Label`.
2. `Label.ID` and `Label.Name` became value fields (`int64` / `string`).

```
pkg/notifier/github/github.go:55:18: g.Issues.EditLabel undefined (type *github.IssuesService has no field or method EditLabel)
pkg/notifier/github/github.go:56:10: cannot use &color (value of type *string) as string value in struct literal
pkg/notifier/github/github_test.go:67:12: cannot use new(int64(371748792)) (value of type *int64) as int64 value in struct literal
```

`IssuesUpdateLabel` now calls `UpdateLabel` with `github.UpdateIssueLabelRequest{Color: &color}`.
Both methods issue the same `PATCH /repos/{owner}/{repo}/labels/{name}`, and `Color` is still a
`*string` on the request type, so the behaviour and the wire format are unchanged.

The two `github.Label` literals in `newFakeAPI` use plain values. The other `new(...)` literals in
that file are left alone: `IssueComment.ID` and `RepositoryComment.ID` are still `*int64` in v90.

`label.go` reads label names through `GetName()`, which go-github still generates, so no other
call site changes.

Verified locally: `go build ./...`, `go vet ./...` and `go test ./...` all pass.

Base is the Renovate branch, so merging this puts the fix on #2444.
